### PR TITLE
Merge CI configuration changes

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,7 @@
+engines:
+  duplication:
+    enabled: true
+    config:
+      languages:
+        python:
+          python_version: 3

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+;config file for the pep8 analysis plugin
+[pep8]
+max-line-length = 100


### PR DESCRIPTION
Update the build configurations to enable Code Climate.
the setup.cfg is for pep8 style checking, the modifications, `.codeclimate.yml` is to set the python language to py 3, as it defaults to python2.

