### PR TITLE
Change Travis to use PyTest as the test runner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ python:
 install:
   - pip install -r requirements.txt
   - pip install coverage
+  - pip install pytest
+  - pip install pytest-cov
 cache: pip
 
 before_script: # code climate init

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,9 @@ before_script: # code climate init
   - ./cc-test-reporter before-build
 
 script:
-  - coverage run -m unittest discover -v -s tests
+  - pytest -v --cov --cov-report xml
 
 after_script: #report the results back to code climate
-  - coverage xml
   - ./cc-test-reporter after-build --coverage-input-type coverage.py --exit-code $TRAVIS_TEST_RESULT
 notifications:
   webhooks:


### PR DESCRIPTION
This PR changes the test environment from the `unittest` framework to `pytest`

The `pyTest` framework appears to be far better suited for our Test Driven Development than `unittest`, and it requires far less effort to create new tests.
`PyTest` also includes many more features that we may be able to leverage to increase the quality of our tests without greatly increasing complexity and overhead.

PyTest will run `unittest` tests, so it is plug and play, and does not require any modification to existing tests to make use of.