### PR TITLE
Implement Rescue.status

### DIFF
--- a/Modules/rat_rescue.py
+++ b/Modules/rat_rescue.py
@@ -537,7 +537,7 @@ class Rescue(object):
             bool: is case open?
 
         """
-        return False if self.status is Status.CLOSED else True
+        return self.status is not Status.CLOSED
 
     @open.setter
     def open(self, value: bool) -> None:

--- a/Modules/rat_rescue.py
+++ b/Modules/rat_rescue.py
@@ -28,10 +28,14 @@ class Rescue(object):
     A unique rescue
     """
 
-    def __init__(self, case_id: UUID, client: str, system: str, irc_nickname: str, board: 'RatBoard' = None,
-                 created_at: datetime = None, updated_at: datetime = None, unidentified_rats=None, active=True,
-                 quotes: list = None, epic=False, title: str = '', first_limpet: UUID or None = None,
-                 board_index: int = None, mark_for_deletion: dict or None = None, lang_id: str = "EN",
+    def __init__(self, case_id: UUID, client: str, system: str, irc_nickname: str,
+                 board: 'RatBoard' = None,
+                 created_at: datetime = None,
+                 updated_at: datetime = None, unidentified_rats=None, active=True,
+                 quotes: list = None, epic=False, title: str = '',
+                 first_limpet: UUID or None = None,
+                 board_index: int = None, mark_for_deletion: dict or None = None,
+                 lang_id: str = "EN",
                  rats: list = None, status: Status = Status.OPEN, code_red=False):
         """
         creates a unique rescue

--- a/Modules/rat_rescue.py
+++ b/Modules/rat_rescue.py
@@ -142,7 +142,7 @@ class Rescue(object):
         return self._status
 
     @status.setter
-    def status(self, value:status):
+    def status(self, value: status):
         """
         Set the value of the status enum
 
@@ -392,7 +392,7 @@ class Rescue(object):
         return False if self.status == Status.INACTIVE else True
 
     @active.setter
-    def active(self, value:bool) -> None:
+    def active(self, value: bool) -> None:
         """
         setter for `Rescue.active`
 
@@ -537,10 +537,7 @@ class Rescue(object):
             bool: is case open?
 
         """
-        if self.status is Status.CLOSED:
-            return False
-        else:
-            return True
+        return False if self.status is Status.CLOSED else True
 
     @open.setter
     def open(self, value: bool) -> None:

--- a/Modules/rat_rescue.py
+++ b/Modules/rat_rescue.py
@@ -389,7 +389,7 @@ class Rescue(object):
         Returns:
             bool: Active state
         """
-        return True if self.status == Status.INACTIVE else False
+        return False if self.status == Status.INACTIVE else True
 
     @active.setter
     def active(self, value:bool) -> None:

--- a/ratlib/names.py
+++ b/ratlib/names.py
@@ -25,6 +25,15 @@ class Platforms(Enum):
     """No platform"""
 
 
+class Status(Enum):
+    """Rescue status enum"""
+    OPEN = 0
+    """The rescue is currently open"""
+    CLOSED = 1
+    """The rescue is currently closed"""
+    INACTIVE = 2
+    """The rescue is open, but is marked inactive"""
+
 def strip_name(nickname: str) -> str:
     """
     This function accepts one input `nickname` and returns the input string

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,8 +36,7 @@ def RescueSoP_fx(request) -> Rescue:
         Rescue : Rescue objects
     """
     params = request.param
-    myRescue = Rescue(uuid4(), client=params[0], system=params[2], irc_nickname=params[0],
-                      board_index=params[3])
+    myRescue = Rescue(uuid4(), client=params[0], system=params[2], irc_nickname=params[0], board_index=params[3])
     myRescue.platform = params[1]
     return myRescue
 
@@ -50,7 +49,7 @@ def RescuePlain_fx() -> Rescue:
     Returns:
         Rescue : Plain initialized Rescue
     """
-    return Rescue(uuid4(), "UNIT_TEST", "ki", "UNIT_TEST",board_index=42)
+    return Rescue(uuid4(), "UNIT_TEST", "ki", "UNIT_TEST", board_index=42)
 
 
 @pytest.fixture

--- a/tests/test_rescue.py
+++ b/tests/test_rescue.py
@@ -32,9 +32,8 @@ class TestRescue(TestCase):
         self.updated_at = datetime(2017, 12, 24, 23, 59, 52)
         self.system = "firestone"
         self.case_id = "some_id"
-        self.rescue = Rescue(self.case_id, "stranded_commander", system=self.system,
-                             irc_nickname="stranded_commander", created_at=self.time,
-                             updated_at=self.updated_at,board_index=42)
+        self.rescue = Rescue(self.case_id, "stranded_commander", system=self.system, irc_nickname="stranded_commander",
+                             created_at=self.time, updated_at=self.updated_at, board_index=42)
 
     def test_client_property_exists(self):
         """
@@ -298,20 +297,20 @@ class TestRescue(TestCase):
 
     def test_is_open_properly(self):
         """
-        Verifies `Rescue.is_open` is readable and settable when thrown good
+        Verifies `Rescue.open` is readable and settable when thrown good
         parameters
 
         Returns:
 
         """
         # check default state
-        self.assertTrue(self.rescue.is_open)
+        self.assertTrue(self.rescue.open)
 
         data = [True, False]
         for value in data:
             with self.subTest(value=value):
-                self.rescue.is_open = value
-                self.assertEqual(self.rescue.is_open, value)
+                self.rescue.open = value
+                self.assertEqual(self.rescue.open, value)
 
     def test_is_open_bad_types(self):
         """
@@ -325,7 +324,7 @@ class TestRescue(TestCase):
         for piece in garbage:
             with self.subTest(piece=piece):
                 with self.assertRaises(TypeError):
-                    self.rescue.is_open = piece
+                    self.rescue.open = piece
 
     def test_epic_readable(self):
         """
@@ -368,36 +367,6 @@ class TestRescue(TestCase):
                 with self.assertRaises(TypeError):
                     self.rescue.code_red = piece
 
-    def test_successful_correctly(self):
-        """
-        Verifies `Rescue.successful` is readable and settable when thrown good
-         parameters
-
-        Returns:
-
-        """
-        # check default state
-        self.assertFalse(self.rescue.successful)
-
-        data = [True, False]
-        for value in data:
-            with self.subTest(value=value):
-                self.rescue.successful = value
-                self.assertEqual(self.rescue.successful, value)
-
-    def test_successful_bad_types(self):
-        """
-        Verifies `Rescue.successful` raises correct exceptions when its given
-        garbage
-
-        Returns:
-
-        """
-        garbage = [None, "foo", {}, 12, 22.3]
-        for piece in garbage:
-            with self.subTest(piece=piece):
-                with self.assertRaises(TypeError):
-                    self.rescue.successful = piece
 
     def test_title(self):
         """

--- a/tests/test_rescue.py
+++ b/tests/test_rescue.py
@@ -10,6 +10,7 @@ See LICENSE.md
 
 This module is built on top of the Pydle system.
 """
+from copy import deepcopy
 from datetime import datetime
 from unittest import TestCase
 from unittest.mock import patch, MagicMock
@@ -610,3 +611,23 @@ class TestRescuePyTests(object):
         with pytest.raises(ValueError):
             RescuePlain_fx.mark_for_deletion = my_md_structure
             assert my_md_structure != RescuePlain_fx.mark_for_deletion
+
+    @pytest.mark.parametrize("garbage", [None, 42, -2.2, []])
+    def test_mark_for_deletion_setter_bad_types(self, garbage, RescuePlain_fx: Rescue):
+        """Verifies attempting to set Rescue.mark_for_deletion to bad types results in a TypeError"""
+        myRescue = deepcopy(RescuePlain_fx)
+
+        with pytest.raises(TypeError):
+            myRescue.mark_for_deletion = garbage
+
+    @pytest.mark.parametrize("garbage", [
+        {'reason': 42, 'marked': True, 'reporter': "UNIT_TEST"},
+        {'reason': None, "marked": 1, 'reporter': "UNIT_TEST"},
+        {'reason': None, "marked": False, "reporter": 21}
+    ])
+    def test_mark_for_deletion_setter_malformed_data(self, garbage, RescuePlain_fx: Rescue):
+        """Verifies attempting to set Rescue.mark_for_deletion to bad types results in a TypeError"""
+        myRescue = deepcopy(RescuePlain_fx)
+
+        with pytest.raises(ValueError):
+            myRescue.mark_for_deletion = garbage


### PR DESCRIPTION
This PR implements the `Rescue.status` property and its Setter.
This property returns an instance of the `Status` enum, which i placed in `ratlib\names.py`

The Status enum includes three states:
`OPEN` case is open and active
`CLOSED` case is marked as closed
`INACTIVE` case is marked as open and inactive

The `Rescue.is_open` property has been renamed `rescue.open` and has been reimplemented to make use of the `Rescue.status` property. The `rescue._open` attribute has been removed.

the `Rescue.inactive` property has been reimplemented to use `Rescue.status` property.
the attribute `Rescue._inactive` has been removed.