### PR TITLE
Implement ability to fetch a rat by uuid alone

### DIFF
--- a/Modules/rat_rescue.py
+++ b/Modules/rat_rescue.py
@@ -712,7 +712,7 @@ class Rescue(object):
         else:
             raise TypeError(f"expected type list got {type(value)}")
 
-    def add_rat(self, name: str = None, guid: UUID or str = None, rat: Rats = None) -> None:
+    async def add_rat(self, name: str = None, guid: UUID or str = None, rat: Rats = None) -> None:
         """
         Adds a rat to the rescue. This method should be run inside a `try` block, as failures will
         be raised as exceptions.
@@ -747,7 +747,7 @@ class Rescue(object):
 
         if isinstance(name, str):
             # lets check if we already have this rat in the cache (platform, any)
-            found = (Rats.get_rat(name, self.platform), Rats.get_rat(name))
+            found = (await Rats.get_rat_by_name(name, self.platform), await Rats.get_rat_by_name(name))
             if found[0]:
                 self.rats.append(found[0])
                 return

--- a/Modules/rat_rescue.py
+++ b/Modules/rat_rescue.py
@@ -758,14 +758,14 @@ class Rescue(object):
                 self.rats.append(found[1])
                 return
 
-        else:
-            # lets make a new Rat!
-            if self.rat_board:  # PRAGMA: NOCOVER
-                raise NotImplementedError  # TODO fetch rat from API
-            # TODO: fetch rats from API handler, use that data to make a new Rats instance
+            else:
+                # lets make a new Rat!
+                if self.rat_board:  # PRAGMA: NOCOVER
+                    raise NotImplementedError  # TODO fetch rat from API
+                # TODO: fetch rats from API handler, use that data to make a new Rats instance
 
-            rat = Rats(name=name, uuid=guid)
-            self.rats.append(rat)
+                rat = Rats(name=name, uuid=guid)
+                self.rats.append(rat)
 
 
     @contextmanager

--- a/Modules/rats.py
+++ b/Modules/rats.py
@@ -165,7 +165,7 @@ class Rats(object):
     @classmethod
     async def get_rat_by_name(cls, name: str,
                               platform: Platforms = Platforms.DEFAULT,
-                              bot=None) -> 'Rats' or None:
+                              ) -> 'Rats' or None:
         """
         Finds a rat by name and optionally by platform
 

--- a/Modules/rats.py
+++ b/Modules/rats.py
@@ -177,6 +177,7 @@ class Rats(object):
             # no such rat in cache
             if cls.apiHandler is not None:
                 found = await cls.apiHandler.someApiCall(name=name)
+                # FIXME: replace SomeApiCall with the actual call once we have the interface
             return found
         else:
             # we found a rat

--- a/Modules/rats.py
+++ b/Modules/rats.py
@@ -203,7 +203,8 @@ class Rats(object):
         """
         Finds a rat by their UUID.
 
-        This method will first check the local cache and, in the event of a cache miss, will make an API call.
+        This method will first check the local cache and, in the event of a cache miss, will make an
+            API call.
 
         Args:
             uuid (UUID): api uuid to find a rat for

--- a/Modules/rats.py
+++ b/Modules/rats.py
@@ -16,8 +16,6 @@ This module is built on top of the Pydle system.
 import logging
 from uuid import UUID
 
-from pydle import BasicClient
-
 import config
 from ratlib.names import Platforms
 
@@ -182,6 +180,30 @@ class Rats(object):
         else:
             # we found a rat
             return found if (found.platform == platform or platform == Platforms.DEFAULT) else None
+
+    @classmethod
+    async def get_rat_by_uuid(cls, uuid: UUID) -> 'Rats' or None:
+        """
+        Finds a rat by their UUID.
+
+        This method will first check the local cache and, in the event of a cache miss, will make an API call.
+
+        Args:
+            uuid (UUID): api uuid to find a rat for
+
+        Returns:
+            Rats: found Rescue
+        """
+        if not isinstance(uuid, UUID):
+            raise TypeError
+        else:
+            found = None
+            if uuid in cls.cache_by_id:
+                found = cls.cache_by_id[uuid]
+            else:
+                found = await cls.apiHandler.someApiCall(uuid=uuid)
+
+            return found
 
     @classmethod
     def flush(cls) -> None:

--- a/Modules/rats.py
+++ b/Modules/rats.py
@@ -191,7 +191,7 @@ class Rats(object):
         except KeyError:
             # no such rat in cache
             if cls.apiHandler is not None:
-                found = await cls.apiHandler.someApiCall(name=name)
+                found = await cls.apiHandler.someApiCall(name=name)  # pragma: no cover
                 # FIXME: replace SomeApiCall with the actual call once we have the interface
             return found
         else:
@@ -217,7 +217,7 @@ class Rats(object):
             found = None
             if uuid in cls.cache_by_id:
                 found = cls.cache_by_id[uuid]
-            elif cls.apiHandler is not None:
+            elif cls.apiHandler is not None:  # pragma: no cover
                 found = await cls.apiHandler.someApiCall(uuid=uuid)
 
             return found

--- a/Modules/rats.py
+++ b/Modules/rats.py
@@ -38,7 +38,7 @@ class Rats(object):
     """Cache of rat objects by their UUID"""
     cache_by_name = {}
     """Cache of rat objects by rat name (str)"""
-    apiHandler = None
+    api_handler = None
     """API handler"""
 
     def __init__(self, uuid: UUID, name: str = None, platform: Platforms = Platforms.DEFAULT):
@@ -190,8 +190,8 @@ class Rats(object):
             found = Rats.cache_by_name[name]
         except KeyError:
             # no such rat in cache
-            if cls.apiHandler is not None:
-                found = await cls.apiHandler.someApiCall(name=name)  # pragma: no cover
+            if cls.api_handler is not None:
+                found = await cls.api_handler.someApiCall(name=name)  # pragma: no cover
                 # FIXME: replace SomeApiCall with the actual call once we have the interface
             return found
         else:
@@ -218,8 +218,8 @@ class Rats(object):
             found = None
             if uuid in cls.cache_by_id:
                 found = cls.cache_by_id[uuid]
-            elif cls.apiHandler is not None:  # pragma: no cover
-                found = await cls.apiHandler.get_rat_by_id(id=uuid)
+            elif cls.api_handler is not None:  # pragma: no cover
+                found = await cls.api_handler.get_rat_by_id(id=uuid)
 
             return found
 

--- a/Modules/rats.py
+++ b/Modules/rats.py
@@ -218,7 +218,7 @@ class Rats(object):
             if uuid in cls.cache_by_id:
                 found = cls.cache_by_id[uuid]
             elif cls.apiHandler is not None:  # pragma: no cover
-                found = await cls.apiHandler.someApiCall(uuid=uuid)
+                found = await cls.apiHandler.get_rat_by_id(id=uuid)
 
             return found
 

--- a/Modules/rats.py
+++ b/Modules/rats.py
@@ -62,6 +62,23 @@ class Rats(object):
             # don't register duplicates
             Rats.cache_by_id[uuid] = self
 
+    def __eq__(self, other: 'Rats')->bool:
+        """
+        Compare two Rats objects for equality
+
+        Args:
+            other (Rats): other object to compare
+
+        Returns:
+            bool: equal if uuid, platform, and name match
+        """
+        conditions = {
+            self.platform == other.platform,
+            self.uuid == other.uuid,
+            self.name == other.name
+        }
+        return all(conditions)
+
     @property
     def uuid(self):
         """
@@ -200,7 +217,7 @@ class Rats(object):
             found = None
             if uuid in cls.cache_by_id:
                 found = cls.cache_by_id[uuid]
-            else:
+            elif cls.apiHandler is not None:
                 found = await cls.apiHandler.someApiCall(uuid=uuid)
 
             return found

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ Licensed under the BSD 3-Clause License.
 
 See LICENSE
 """
-from uuid import uuid4
+from uuid import uuid4, UUID
 
 import pytest
 
@@ -62,16 +62,16 @@ def RatNoID_fx():
     return Rats(None, "noIdRat")
 
 
-@pytest.fixture(params=[("myPcRat", Platforms.PC),
-                        ("someXrat", Platforms.XB),
-                        ("psRatToTheRescue", Platforms.PS)],
-                scope='module')
+@pytest.fixture(params=[("myPcRat", Platforms.PC, UUID("dead4ac0-0000-0000-0000-00000000beef")),
+                        ("someXrat", Platforms.XB, UUID("FEED000-FAC1-0000-0000900000D15EA5E")),
+                        ("psRatToTheRescue", Platforms.PS, UUID("FEE1DEA-DFAC-0000-000001BADB001FEED"))],
+                )
 def RatGood_fx(request) -> Rats:
     """
     Testing fixture containing good and registered rats
     """
     params = request.param
-    myRat = Rats(uuid4(), name=params[0], platform=params[1])
+    myRat = Rats(params[2], name=params[0], platform=params[1])
     return myRat
 
 

--- a/tests/test_Rats.py
+++ b/tests/test_Rats.py
@@ -189,3 +189,11 @@ class TestRatsPyTest(object):
 
         with pytest.raises(TypeError):
             await Rats.get_rat_by_name(name="foo", platform=garbage)
+
+    @pytest.mark.asyncio
+    async def test_find_rat_not_in_cache_and_no_API(self):
+        """
+        Verifies the functionality of Rats.get_rat_by_nickname when the rat is not in the cache
+        """
+        result = await Rats.get_rat_by_name(name="somenamethatdoesnotexist")
+        assert result is None

--- a/tests/test_Rats.py
+++ b/tests/test_Rats.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from unittest import TestCase
 from uuid import UUID, uuid4
 
@@ -180,7 +181,7 @@ class TestRatsPyTest(object):
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("garbage", [22.1, -42, 42, 0, False, True])
-    async def test_find_rat_bad_type(self, garbage):
+    async def test_find_rat_by_name_bad_type(self, garbage):
         """
         Verifies that attempting to throw garbage at Rats.search() raises the proper exception
         """
@@ -191,9 +192,30 @@ class TestRatsPyTest(object):
             await Rats.get_rat_by_name(name="foo", platform=garbage)
 
     @pytest.mark.asyncio
-    async def test_find_rat_not_in_cache_and_no_API(self):
+    async def test_find_rat_by_name_not_in_cache_and_no_API(self):
         """
         Verifies the functionality of Rats.get_rat_by_nickname when the rat is not in the cache
         """
         result = await Rats.get_rat_by_name(name="somenamethatdoesnotexist")
         assert result is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("garbage", [22.1, -42, 42, 0, False, True])
+    async def test_get_rat_by_uuid_garbage(self, garbage):
+        with pytest.raises(TypeError):
+            await Rats.get_rat_by_uuid(uuid=garbage)
+
+    @pytest.mark.asyncio
+    async def test_get_rat_by_uuid_cache_miss(self):
+        """Verifies Rats.get_rat_by_uuid returns None upon cache miss and no API connection"""
+        uuid = uuid4()
+        assert await Rats.get_rat_by_uuid(uuid) is None
+
+    @pytest.mark.asyncio
+    async def test_get_rat_by_uuid_cache_hit(self, RatGood_fx: Rats):
+        """Verifies Rats.get_rat_by_uuid returns the correct rat on cache hit"""
+        mine = RatGood_fx
+        found = await Rats.get_rat_by_uuid(mine.uuid)
+        assert found is not None
+        assert found == mine
+

--- a/tests/test_Rats.py
+++ b/tests/test_Rats.py
@@ -1,4 +1,3 @@
-from copy import deepcopy
 from unittest import TestCase
 from uuid import UUID, uuid4
 
@@ -57,23 +56,6 @@ class TestRat(TestCase):
         # verify the keys exist and store the expected data
         self.assertEqual(Rats.cache_by_id[self.some_id], self.my_rat)
         self.assertEqual(Rats.cache_by_name["UNIT_TEST"], self.my_rat)
-
-    @pytest.mark.asyncio
-    async def test_find_rat_by_name_existing(self):
-        """
-        Verifies that cached rats can be found by name
-        """
-        found_rat = await Rats.get_rat_by_name(name="UNIT_TEST")
-        assert self.my_rat == found_rat
-
-    @pytest.mark.asyncio
-    async def test_find_rat_incorrect_platform(self):
-        """
-        Verifies that `Rats.get_rat_by_name` called with a specific platform that does not match
-            the stored platform returns None
-        """
-        found_rat = await Rats.get_rat_by_name(name="UNIT_TEST", platform=Platforms.XB)
-        self.assertIsNone(found_rat)
 
     def test_first_limpet(self):
         """
@@ -219,3 +201,24 @@ class TestRatsPyTest(object):
         assert found is not None
         assert found == mine
 
+
+    @pytest.mark.asyncio
+    async def test_find_rat_by_name_existing(self, RatGood_fx: Rats):
+        """
+        Verifies that cached rats can be found by name
+        """
+        found_rat = await Rats.get_rat_by_name(name=RatGood_fx.name)
+        assert RatGood_fx == found_rat
+
+    @pytest.mark.asyncio
+    async def test_find_rat_incorrect_platform(self):
+        """
+        Verifies that `Rats.get_rat_by_name` called with a specific platform that does not match
+            the stored platform returns None
+        """
+        Rats(name="UNIT_TEST", uuid=None, platform=Platforms.PC)
+
+        found_rat = await Rats.get_rat_by_name(name="UNIT_TEST", platform=Platforms.XB)
+
+        assert found_rat is None
+        # pytest.fail("not awaited!")

--- a/tests/test_Rats.py
+++ b/tests/test_Rats.py
@@ -57,32 +57,22 @@ class TestRat(TestCase):
         self.assertEqual(Rats.cache_by_id[self.some_id], self.my_rat)
         self.assertEqual(Rats.cache_by_name["UNIT_TEST"], self.my_rat)
 
-    def test_find_rat_by_name_existing(self):
+    @pytest.mark.asyncio
+    async def test_find_rat_by_name_existing(self):
         """
         Verifies that cached rats can be found by name
         """
-        found_rat = Rats.get_rat(name="UNIT_TEST")
-        self.assertEqual(found_rat, self.my_rat)
+        found_rat = await Rats.get_rat_by_name(name="UNIT_TEST")
+        assert self.my_rat == found_rat
 
-    def test_find_rat_incorrect_platform(self):
+    @pytest.mark.asyncio
+    async def test_find_rat_incorrect_platform(self):
         """
-        Verifies that `Rats.get_rat` called with a specific platform that does not match
+        Verifies that `Rats.get_rat_by_name` called with a specific platform that does not match
             the stored platform returns None
         """
-        found_rat = Rats.get_rat(name="UNIT_TEST", platform=Platforms.XB)
+        found_rat = await Rats.get_rat_by_name(name="UNIT_TEST", platform=Platforms.XB)
         self.assertIsNone(found_rat)
-
-    def test_find_rat_bad_type(self):
-        """
-        Verifies that attempting to throw garbage at Rats.search() raises the proper exception
-        """
-        garbage = ['foo', -42, 42, 0, False, True]
-        for piece in garbage:
-            # self.fail("Not implemented yet, as the functionality doesn't exist!")
-            with self.subTest(piece=piece):
-                with self.assertRaises(TypeError):
-                    Rats.get_rat(name=piece)
-                    Rats.get_rat(name="foo", platform=piece)
 
     def test_first_limpet(self):
         """
@@ -99,7 +89,7 @@ class TestRat(TestCase):
             rescue.first_limpet = guid
             self.assertEqual(rescue.first_limpet, guid)
 
-        #reset for next subtest
+        # reset for next subtest
         rescue._firstLimpet = None
         guid_str = str(guid)
         with self.subTest(mode="good string", guid=guid_str):
@@ -107,7 +97,7 @@ class TestRat(TestCase):
             self.assertEqual(rescue.first_limpet, guid)
 
         rescue._firstLimpet = None
-        garbage = [[],{}, "foo","bar",-2]
+        garbage = [[], {}, "foo", "bar", -2]
         for piece in garbage:
             with self.subTest(mode="garbage", piece=piece):
                 with self.assertRaises(TypeError):
@@ -187,3 +177,15 @@ class TestRatsPyTest(object):
         my_rat = Rats(None, "potato", Platforms.PC)
         with pytest.raises(TypeError):
             my_rat.platform = garbage
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("garbage", [22.1, -42, 42, 0, False, True])
+    async def test_find_rat_bad_type(self, garbage):
+        """
+        Verifies that attempting to throw garbage at Rats.search() raises the proper exception
+        """
+        with pytest.raises(TypeError):
+            await Rats.get_rat_by_name(name=garbage)
+
+        with pytest.raises(TypeError):
+            await Rats.get_rat_by_name(name="foo", platform=garbage)

--- a/tests/test_Rats.py
+++ b/tests/test_Rats.py
@@ -201,6 +201,9 @@ class TestRatsPyTest(object):
         assert found is not None
         assert found == mine
 
+    def test_rat_eq_true(self, RatGood_fx: Rats):
+        """Verifies Rats.__eq__ functions correctly against equal objects"""
+        assert RatGood_fx == RatGood_fx
 
     @pytest.mark.asyncio
     async def test_find_rat_by_name_existing(self, RatGood_fx: Rats):

--- a/tests/test_rescue.py
+++ b/tests/test_rescue.py
@@ -368,7 +368,6 @@ class TestRescue(TestCase):
                 with self.assertRaises(TypeError):
                     self.rescue.code_red = piece
 
-
     def test_title(self):
         """
         Verifies `Rescue.title` behaves as expected
@@ -409,24 +408,12 @@ class TestRescue(TestCase):
                 with self.assertRaises(TypeError):
                     self.rescue.rats = piece
 
-    def test_add_rat_by_rat_boject(self):
-        """
-        Verifies `Rescue.add_rat` can add a rat given a `Rats` object
-        """
-        rats_raw = [(uuid4(), "foo"), (uuid4(), "bar"), (uuid4(), "potato")]
-        rats = [Rats(x, y) for x, y in rats_raw]
-
-        for rat in rats:
-            with self.subTest(rat=rat):
-                self.rescue.add_rat(rat=rat)
-                self.assertIn(rat, self.rescue._rats)
-
     def test_add_rat_by_uuid(self):
         """
         Verifies `Rescue.add_rat` can add a rat given a guid and a name
         """
         rats_raw = [(uuid4(), "foo"), (uuid4(), "bar"), (uuid4(), "potato")]
-        for guid,name in rats_raw:
+        for guid, name in rats_raw:
             with self.subTest(guid=guid, name=name):
                 self.rescue.add_rat(guid)
 
@@ -478,16 +465,18 @@ class TestRescuePyTests(object):
     container for pytest specific tests
     """
 
-    def test_add_rats_bad_id(self, RatNoID_fx, RescueSoP_fx):
+    @pytest.mark.asyncio
+    async def test_add_rats_bad_id(self, RatNoID_fx, RescueSoP_fx):
         """
         Verifies attempting to add a rat that does not have a API id fails as expected
         """
         with pytest.raises(ValueError, message="Assigned rat does not have a known API ID"):
-            RescueSoP_fx.add_rat(rat=RatNoID_fx)
+            await RescueSoP_fx.add_rat(rat=RatNoID_fx)
 
         assert RatNoID_fx not in RescueSoP_fx.rats
 
-    def test_add_rats_ok(self, RatGood_fx, RescueSoP_fx):
+    @pytest.mark.asyncio
+    async def test_add_rats_ok(self, RatGood_fx, RescueSoP_fx):
         """
         Verifies adding a existing rat with a UUID works
         Args:
@@ -495,11 +484,12 @@ class TestRescuePyTests(object):
             RescueSoP_fx (Rescue):  Rescue object Test Fixture
         """
         # RescueSoP_fx:Rescue
-        RescueSoP_fx.add_rat(rat=RatGood_fx)
+        await RescueSoP_fx.add_rat(rat=RatGood_fx)
         assert RatGood_fx in RescueSoP_fx.rats
 
-    def test_add_rat_from_cache(self, RatGood_fx: Rats, RescueSoP_fx: Rescue):
-        RescueSoP_fx.add_rat(RatGood_fx.name)
+    @pytest.mark.asyncio
+    async def test_add_rat_from_cache(self, RatGood_fx: Rats, RescueSoP_fx: Rescue):
+        await RescueSoP_fx.add_rat(RatGood_fx.name)
         assert RatGood_fx in RescueSoP_fx.rats
 
     @pytest.mark.parametrize("garbage", [(None,), (42,), (-2.2,), (uuid4(),)])
@@ -631,3 +621,20 @@ class TestRescuePyTests(object):
 
         with pytest.raises(ValueError):
             myRescue.mark_for_deletion = garbage
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("uuid,name", [(uuid4(), "foo"), (uuid4(), "bar"), (uuid4(), "potato")])
+    async def test_add_rat_by_rat_object(self, uuid: uuid4, name: str, RescuePlain_fx: Rescue):
+        """
+        Verifies `Rescue.add_rat` can add a rat given a `Rats` object
+        """
+        # rats_raw = [(uuid4(), "foo"), (uuid4(), "bar"), (uuid4(), "potato")]
+        # rats = [Rats(x, y) for x, y in rats_raw]
+
+        myRescue = deepcopy(RescuePlain_fx)
+
+        rat = Rats(uuid=uuid, name=name)
+
+        await myRescue.add_rat(rat=rat)
+
+        assert rat in myRescue.rats

--- a/tests/test_rescue.py
+++ b/tests/test_rescue.py
@@ -408,14 +408,7 @@ class TestRescue(TestCase):
                 with self.assertRaises(TypeError):
                     self.rescue.rats = piece
 
-    def test_add_rat_by_uuid(self):
-        """
-        Verifies `Rescue.add_rat` can add a rat given a guid and a name
-        """
-        rats_raw = [(uuid4(), "foo"), (uuid4(), "bar"), (uuid4(), "potato")]
-        for guid, name in rats_raw:
-            with self.subTest(guid=guid, name=name):
-                self.rescue.add_rat(guid)
+
 
     def test_eq_true_branch(self):
         """
@@ -638,3 +631,16 @@ class TestRescuePyTests(object):
         await myRescue.add_rat(rat=rat)
 
         assert rat in myRescue.rats
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("uuid,name", [(uuid4(), "foo"), (uuid4(), "bar"), (uuid4(), "potato")])
+    async def test_add_rat_by_uuid(self, uuid: uuid4, name: str, RescuePlain_fx: Rescue):
+        """
+        Verifies `Rescue.add_rat` can add a rat given a guid and a name
+        """
+        myRescue = deepcopy(RescuePlain_fx)
+
+        await myRescue.add_rat(name=name, guid=uuid)
+
+        assert name in Rats.cache_by_name
+

--- a/tests/test_rescue.py
+++ b/tests/test_rescue.py
@@ -483,7 +483,7 @@ class TestRescuePyTests(object):
     @pytest.mark.asyncio
     async def test_add_rat_from_cache(self, RatGood_fx: Rats, RescueSoP_fx: Rescue):
         await RescueSoP_fx.add_rat(RatGood_fx.name)
-        assert RatGood_fx in RescueSoP_fx.rats
+        assert RatGood_fx == RescueSoP_fx.rats[0]
 
     @pytest.mark.parametrize("garbage", [(None,), (42,), (-2.2,), (uuid4(),)])
     def test_irc_nickname_garbage(self, garbage, RescuePlain_fx: Rescue):


### PR DESCRIPTION
This PR adds a method `Rats.get_rat_from_uuid` and refactors `Rats.get_rat` into `Rats.get_rat_by_name`
Both methods are now async due to the API calls, associated tests have been updated respectively.

Both new functions will first check their respective client-side Rats class attribute caches and, in the event of a cache miss, make an API query (TODO: requires API interface) to fetch the rat from the API.

This PR also Adds `Rats.__eq__`, and fixes a couple elusive bugs in Rats and their associated tests. `RatGood_fx` now uses hard-coded UUIDs to remove randomness from that part of the test suite, this helped simplify debugging of a bigger problem (which is why I implemented a `Rats.__eq__` method.)
Further, the scope of `RatGood_fx` has been lowered back to test level, as the underlying bug that required them to be at a higher scope has been fixed. Woops.

