### PR TITLE
Make Trigger and Permission objects hashable and more or less immutable (SPARK-12)

### DIFF
--- a/Modules/permissions.py
+++ b/Modules/permissions.py
@@ -14,6 +14,8 @@ This module is built on top of the Pydle system.
 import logging
 from functools import wraps
 
+import sys
+
 import config
 
 log = logging.getLogger(f"{config.Logging.base_logger}.Permissions")
@@ -33,9 +35,13 @@ class Permission:
         :return:
         """
         log.debug(f"created new Permission object with permission level")
-        self.level = level
-        self.vhost = vhost
-        self.denied_message = deny_message
+        self._level = level
+        self._vhost = vhost
+        self._denied_message = deny_message
+
+    level = property(lambda self: self._level)
+    vhost = property(lambda self: self._vhost)
+    denied_message = property(lambda self: self._denied_message)
 
     def __eq__(self, other: 'Permission') -> bool:
         return self.level == other.level
@@ -54,6 +60,19 @@ class Permission:
 
     def __gt__(self, other: 'Permission') -> bool:
         return self.level > other.level
+
+    def __hash__(self):
+        if self._hash is None:
+            attrs = (self._level, self._vhost, self._denied_message)
+
+            offset = sys.hash_info.width
+            interval = offset // len(attrs)
+            self._hash = 0
+            for attr in attrs:
+                offset -= interval
+                self._hash |= hash(attr) << offset
+
+        return self._hash
 
 
 # the uninitiated

--- a/Modules/permissions.py
+++ b/Modules/permissions.py
@@ -14,8 +14,6 @@ This module is built on top of the Pydle system.
 import logging
 from functools import wraps
 
-import sys
-
 import config
 
 log = logging.getLogger(f"{config.Logging.base_logger}.Permissions")
@@ -62,17 +60,7 @@ class Permission:
         return self.level > other.level
 
     def __hash__(self):
-        if self._hash is None:
-            attrs = (self._level, self._vhost, self._denied_message)
-
-            offset = sys.hash_info.width
-            interval = offset // len(attrs)
-            self._hash = 0
-            for attr in attrs:
-                offset -= interval
-                self._hash |= hash(attr) << offset
-
-        return self._hash
+        return hash(self.level)
 
 
 # the uninitiated

--- a/Modules/trigger.py
+++ b/Modules/trigger.py
@@ -112,7 +112,7 @@ class Trigger(object):
             else:
                 return True
         else:
-            return super().__eq__(other)
+            return False
 
     def __hash__(self) -> int:
         if self._hash is None:

--- a/Modules/trigger.py
+++ b/Modules/trigger.py
@@ -100,6 +100,19 @@ class Trigger(object):
         """
         await self.bot.message(self.channel if self.channel else self.nickname, msg)
 
+    def __eq__(self, other):
+        if self is other:
+            return True
+        elif isinstance(other, Trigger):
+            for name, value in Trigger.__dict__.items():
+                if isinstance(value, property):
+                    if getattr(self, name) != getattr(other, name):
+                        return False
+            else:
+                return True
+        else:
+            return super().__eq__(other)
+
     def __hash__(self):
         if self._hash is None:
             attrs = (self._words_eol[0], self._nickname, self._target, self._ident, self._hostname,

--- a/Modules/trigger.py
+++ b/Modules/trigger.py
@@ -1,7 +1,8 @@
+from functools import reduce
+from operator import xor
 from typing import List
 
 import pydle
-import sys
 
 
 class Trigger(object):
@@ -100,7 +101,7 @@ class Trigger(object):
         """
         await self.bot.message(self.channel if self.channel else self.nickname, msg)
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         if self is other:
             return True
         elif isinstance(other, Trigger):
@@ -113,16 +114,10 @@ class Trigger(object):
         else:
             return super().__eq__(other)
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         if self._hash is None:
             attrs = (self._words_eol[0], self._nickname, self._target, self._ident, self._hostname,
                      self._realname, self._away, self._account)
-
-            offset = sys.hash_info.width
-            interval = offset // len(attrs)
-            self._hash = 0
-            for attr in attrs:
-                offset -= interval
-                self._hash |= hash(attr) << offset
+            self._hash = reduce(xor, map(hash, attrs))
 
         return self._hash

--- a/Modules/trigger.py
+++ b/Modules/trigger.py
@@ -1,6 +1,7 @@
 from typing import List
 
 import pydle
+import sys
 
 
 class Trigger(object):
@@ -44,6 +45,8 @@ class Trigger(object):
         self.account = account
         self.identified = identified
 
+        self._hash = None
+
     @classmethod
     def from_bot_user(cls, bot: pydle.BasicClient, nickname: str, target: str, words: List[str],
                       words_eol: List[str] = None) -> 'Trigger':
@@ -83,3 +86,17 @@ class Trigger(object):
             msg (str): Message to send.
         """
         await self.bot.message(self.channel if self.channel else self.nickname, msg)
+
+    def __hash__(self):
+        if self._hash is None:
+            attrs = (self.words_eol[0], self.nickname, self.target, self.ident, self.hostname,
+                     self.realname, self.away, self.account)
+
+            offset = sys.hash_info.width
+            interval = offset // len(attrs)
+            self._hash = 0
+            for attr in attrs:
+                offset -= interval
+                self._hash |= hash(attr) << offset
+
+        return self._hash

--- a/Modules/trigger.py
+++ b/Modules/trigger.py
@@ -33,19 +33,32 @@ class Trigger(object):
                 nickname.
             identified (bool): Whether or not the user is identified with NickServ.
         """
-        self.bot = bot
-        self.words = words
-        self.words_eol = words_eol
-        self.nickname = nickname
-        self.target = target
-        self.ident = ident
-        self.hostname = hostname
-        self.realname = realname
-        self.away = away
-        self.account = account
-        self.identified = identified
+        self._bot = bot
+        self._words = words
+        self._words_eol = words_eol
+        self._nickname = nickname
+        self._target = target
+        self._ident = ident
+        self._hostname = hostname
+        self._realname = realname
+        self._away = away
+        self._account = account
+        self._identified = identified
 
         self._hash = None
+        self._immutable = True
+
+    bot = property(lambda self: self._bot)
+    words = property(lambda self: self._words)
+    words_eol = property(lambda self: self._words_eol)
+    nickname = property(lambda self: self._nickname)
+    target = property(lambda self: self._target)
+    ident = property(lambda self: self._ident)
+    hostname = property(lambda self: self._hostname)
+    realname = property(lambda self: self._realname)
+    away = property(lambda self: self._away)
+    account = property(lambda self: self._account)
+    identified = property(lambda self: self._identified)
 
     @classmethod
     def from_bot_user(cls, bot: pydle.BasicClient, nickname: str, target: str, words: List[str],
@@ -89,8 +102,8 @@ class Trigger(object):
 
     def __hash__(self):
         if self._hash is None:
-            attrs = (self.words_eol[0], self.nickname, self.target, self.ident, self.hostname,
-                     self.realname, self.away, self.account)
+            attrs = (self._words_eol[0], self._nickname, self._target, self._ident, self._hostname,
+                     self._realname, self._away, self._account)
 
             offset = sys.hash_info.width
             interval = offset // len(attrs)

--- a/Modules/trigger.py
+++ b/Modules/trigger.py
@@ -47,7 +47,6 @@ class Trigger(object):
         self._identified = identified
 
         self._hash = None
-        self._immutable = True
 
     bot = property(lambda self: self._bot)
     words = property(lambda self: self._words)

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -14,6 +14,7 @@ This module is built on top of the Pydle system.
 
 """
 import unittest
+from itertools import product
 
 from aiounittest import async_test
 
@@ -120,3 +121,10 @@ class PermissionTests(unittest.TestCase):
             "target": "#somechannel",
             "message": permissions.OVERSEER.denied_message
         }, self.bot.sent_messages)
+
+    def test_hash(self):
+        for perm1, perm2 in product(permissions._by_vhost.values(), permissions._by_vhost.values()):
+            if perm1 == perm2:
+                assert hash(perm1) == hash(perm2)
+            else:
+                assert hash(perm1) != hash(perm2)

--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -63,3 +63,36 @@ async def test_reply_query(bot_fx):
         "target": "test_nick",
         "message": "Exceedingly smart test message."
     } in bot_fx.sent_messages
+
+def test_trigger_eq(bot_fx):
+    trigger1 = Trigger(bot_fx, ["some", "thing"], ["some thing", "thing"], "test_nick",
+                       "not_a_channel", "test_ident", "test.vhost")
+    trigger2 = Trigger(bot_fx, ["some", "thing"], ["some thing", "thing"], "test_nick",
+                       "not_a_channel", "test_ident", "test.vhost")
+
+    assert trigger1 == trigger1
+    assert trigger2 == trigger2
+
+    assert trigger1 == trigger2
+    assert trigger2 == trigger1
+
+def test_trigger_ne(bot_fx):
+    trigger1 = Trigger(bot_fx, ["some", "thing"], ["some thing", "thing"], "test_nick",
+                       "not_a_channel", "test_ident", "test.vhost")
+    trigger2 = Trigger(bot_fx, ["some", "thing"], ["another thing", "thing"], "stupid_nick",
+                       "not_a_channel", "test_ident", "go.away")
+
+    assert trigger1 != trigger2
+    assert trigger2 != trigger1
+
+def test_trigger_hash():
+    trigger1 = Trigger(None, ["some", "thing"], ["some thing", "thing"], "test_nick",
+                       "not_a_channel", "test_ident", "test.vhost")
+    trigger2 = Trigger(None, ["some", "thing"], ["some thing", "thing"], "test_nick",
+                       "not_a_channel", "test_ident", "test.vhost")
+    trigger3 = Trigger(None, ["some", "thing"], ["another thing", "thing"], "stupid_nick",
+                       "not_a_channel", "test_ident", "go.away")
+
+    assert hash(trigger1) == hash(trigger2)
+    assert hash(trigger1) != hash(trigger3)
+    assert hash(trigger2) != hash(trigger3)


### PR DESCRIPTION
This PR implements `__hash__` methods for the Trigger and Permission objects.
It also implements an `__eq__` method for the Trigger object and makes both objects relatively immutable.

The Trigger object's `__hash__` simply xors the hashes of its key attributes together, but it only does it once when the hash is first needed. The Permission's `__hash__` just uses the permission level to be in line with its `__eq__` method.

I likely won't give the API handlers `__eq__` and `__hash__` methods because, on seconds thought, that's pretty fucking pointless.