### PR TITLE
Enable Docker Support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+# ignore python bytecode files
+*.pyc

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,2 @@
-# ignore python bytecode files
-*.pyc
+# Ignore generated files
+**/*.pyc

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,5 @@
 # Ignore generated files
 **/*.pyc
+
+# ignore the git history
+.git*/*

--- a/Docker.md
+++ b/Docker.md
@@ -40,7 +40,8 @@ to run the irc bot itself, enter the following command into your terminal
 ```docker-compose up mecha3```
 
 ## Default executable state of the container
-By default, the mecha3 container will execute the test suite
+By default, the mecha3 container will execute the test suite.
+
 Running the container directly via
 ```docker run mecha3``` is identical to running the tests as described
     above.

--- a/Docker.md
+++ b/Docker.md
@@ -1,0 +1,46 @@
+# Docker Support
+MechaSqueak3 now has Docker support, and can be run from a Docker
+container almost as easily as if run natively.
+
+## Requirements
+Docker. Obviously.
+    - It must be able of running linux containers, we arn't targetting
+    windows here.
+
+Docker-compose - It should come shipped with your Docker install
+    but if it is not, you will need to install it.
+
+
+## Building the container
+In order to use Mechasqueak within a container, you will need to build
+    the container. Doing so is pretty streight forward.
+
+1. clone the project down
+        - no need to install dependencies or anything, this is handled
+        in the next step
+2. run `docker-compose build`
+        - this builds the mecha3 container
+        - you may be asked to grant Docker permission to access the
+            drive you cloned mecha3 to, this is to allow mecha3 to write
+            its logs back to non-volitile diskspace.
+        - logs will be stored in `$PROJECT_ROOT/logs`
+## Running mecha3
+Once the container is built its pretty streight forward to running
+    mechasqueak3.
+
+It is advised to run the test suite first to ensure the build process
+    did not do anything unexpected.
+
+### Running the Test Suite
+to run the test suite enter the following command into your terminal:
+    ```docker-compose up tests```
+
+### Running the Bot itself
+to run the irc bot itself, enter the following command into your terminal
+```docker-compose up mecha3```
+
+## Default executable state of the container
+By default, the mecha3 container will execute the test suite
+Running the container directly via
+```docker run mecha3``` is identical to running the tests as described
+    above.

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,14 +18,12 @@ FROM python:3.6.5-alpine
 COPY ./requirements.txt ./
 # fetch git, as we will need it.
 RUN apk add --no-cache git
-# Copy the current directory contents into the container at /app
-ADD . /mechasqueak
 
 # Install any needed packages specified in requirements.txt
 RUN pip install --trusted-host pypi.python.org -r /requirements.txt
 
+# Copy the current directory contents into the container at /app
+ADD . /mechasqueak
+
 # Set the working directory to /mechasqueak
 WORKDIR /mechasqueak
-
-# Run our tests when the container launches by default
-CMD ["pytest"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,13 +14,15 @@
 
 # Use an official Python runtime as a parent image
 FROM python:3.6.5-alpine
+
+COPY ./requirements.txt ./
 # fetch git, as we will need it.
 RUN apk add --no-cache git
 # Copy the current directory contents into the container at /app
 ADD . /mechasqueak
 
 # Install any needed packages specified in requirements.txt
-RUN pip install --trusted-host pypi.python.org -r /mechasqueak/requirements.txt
+RUN pip install --trusted-host pypi.python.org -r /requirements.txt
 
 # Set the working directory to /mechasqueak
 WORKDIR /mechasqueak

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,15 @@
 # Use an official Python runtime as a parent image
-FROM python:3.6.5-stretch
-
-
+FROM python:3.6.5-alpine
+# fetch git, as we will need it.
+RUN apk add --no-cache git
 # Copy the current directory contents into the container at /app
-ADD . /app
+ADD . /mechasqueak
 
 # Install any needed packages specified in requirements.txt
-RUN pip install --trusted-host pypi.python.org -r /app/requirements.txt
+RUN pip install --trusted-host pypi.python.org -r /mechasqueak/requirements.txt
 
-# Make port 80 available to the world outside this container
-#EXPOSE 80
-
-# Set the working directory to /app
-WORKDIR /app
+# Set the working directory to /mechasqueak
+WORKDIR /mechasqueak
 
 # Run our tests when the container launches by default
 CMD ["pytest"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,17 @@
+#
+#Dockerfile - build script for the mechasqueak3 irc bot
+#    this script will create the runtime environment necessary to run the bot and, by default
+#    invocation, run the Unit Tests.
+#
+#Copyright (c) 2018 The Fuel Rats Mischief,
+#All rights reserved.
+#
+#Licensed under the BSD 3-Clause License.
+#
+#See LICENSE.md
+#
+
+
 # Use an official Python runtime as a parent image
 FROM python:3.6.5-alpine
 # fetch git, as we will need it.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# Use an official Python runtime as a parent image
+FROM python:3.6.5-stretch
+
+
+# Copy the current directory contents into the container at /app
+ADD . /app
+
+# Install any needed packages specified in requirements.txt
+RUN pip install --trusted-host pypi.python.org -r /app/requirements.txt
+
+# Make port 80 available to the world outside this container
+#EXPOSE 80
+
+# Set the working directory to /app
+WORKDIR /app
+
+# Run our tests when the container launches by default
+CMD ["pytest"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+#
+#docker-compose.yml - build script for the mechasqueak3 irc bot
+#   creates the runtime environment for the IRC bot and, by default, runs both the tests and the
+#    client.
+#
+#    USAGE:
+#       test runner:  docker-compose up tests
+#       IRC client:   docker-compose up mecha3
+#
+#Copyright (c) 2018 The Fuel Rats Mischief,
+#All rights reserved.
+#
+#Licensed under the BSD 3-Clause License.
+#
+#See LICENSE.md
+#
+
+version: '3'
+services:
+  tests:
+    volumes:
+      - ./logs :/logs
+    build: .
+    image: mecha3
+    command: "pytest"
+
+  mecha3:
+    volumes:
+      - ./logs :/logs
+    build: .
+    image: mecha3
+    command: ["python","main.py"]


### PR DESCRIPTION
This PR enables the ability for Mecha to run within a Docker Container.
Specifically, mecha3's container is build off Alpine Linux, a minimalistic Linux distribution.
The only things added to it are Git, Mecha's codebase, and her dependencies.

Docker will allow us to have a uniform testing environment, outside what Travis provides. Further, It is to my understanding mecha3 may end up running within a container when she goes live. This facilitates that intention. 

Trezy, asking you to review things as you have Docker experience more than I, please let me know if you spot something obviously flawed with my approach 😄 