### PR TITLE
SPARK-30: MarkForDeletion object

### DIFF
--- a/Modules/mark_for_deletion.py
+++ b/Modules/mark_for_deletion.py
@@ -18,9 +18,8 @@ class MarkForDeletion(object):
     Data object representing a MD structurefrom the API
     """
 
-    def __init__(self, marked: bool = False,
-                 reason: Optional[str] = None,
-                 reporter: Optional[str] = None):
+    def __init__(self, marked: bool = False, reporter: Optional[str] = None,
+                 reason: Optional[str] = None):
         """
         Creates a new MD object
 

--- a/Modules/mark_for_deletion.py
+++ b/Modules/mark_for_deletion.py
@@ -1,0 +1,119 @@
+"""
+mark_for_deletion.py - Mark for Deletion object
+
+Provides a class model for the FR API Mark for Deletion(tm) object
+
+Copyright (c) 2018 The Fuel Rats Mischief,
+All rights reserved.
+
+Licensed under the BSD 3-Clause License.
+
+See LICENSE.md
+"""
+from typing import Optional
+
+
+class MarkForDeletion(object):
+    """
+    Data object representing a MD structurefrom the API
+    """
+
+    def __init__(self, marked: bool, reason: Optional[str], reporter: Optional[str]):
+        """
+        Creates a new MD object
+
+        Args:
+            marked (bool): Indicates whether the object is marked for deletion
+            reason (str): Reported reason for deleting the Rescue
+            reporter (str): IRC nickname of the user that marked the case for deletion
+        """
+        self._reporter = reporter
+        self._marked = marked
+        self._reason = reason
+
+    @property
+    def marked(self) -> bool:
+        """
+        Marker indicating whether the Rescue is marked for deletion
+
+        Returns:
+            bool
+        """
+        return self._marked
+
+    @marked.setter
+    def marked(self, value: bool) -> None:
+        """
+        Set the MD status
+
+        Args:
+            value (bool): MD status
+
+        Returns:
+            None
+
+        Raises:
+            TypeError: invalid type
+        """
+        if isinstance(value, bool):
+            self._marked = value
+        else:
+            raise TypeError
+
+    @property
+    def reason(self) -> str:
+        """
+        Reported reason for marking the case as deleted
+
+        Returns:
+            str: reported reason
+        """
+        return self._reason
+
+    @reason.setter
+    def reason(self, value: str) -> None:
+        """
+        Set the MD reason
+
+        Args:
+            value (str): MD reason string
+
+        Returns:
+            None
+
+        Raises:
+            TypeError: invalid type
+        """
+        if isinstance(value, str):
+            self._reason = value
+        else:
+            raise TypeError
+
+    @property
+    def reporter(self) -> str:
+        """
+        IRC nickname of reporting user
+
+        Returns:
+            str: string nickname
+        """
+        return self._reporter
+
+    @reporter.setter
+    def reporter(self, value: str) -> None:
+        """
+        Sets the reporter
+
+        Args:
+            value (str): reporters nickname
+
+        Returns:
+            None
+
+        Raises:
+            TypeError: invalid type
+        """
+        if isinstance(value, str):
+            self._reporter = value
+        else:
+            raise TypeError

--- a/Modules/mark_for_deletion.py
+++ b/Modules/mark_for_deletion.py
@@ -72,7 +72,7 @@ class MarkForDeletion(object):
         return self._reason
 
     @reason.setter
-    def reason(self, value: str) -> None:
+    def reason(self, value: Optional[str]) -> None:
         """
         Set the MD reason
 
@@ -101,7 +101,7 @@ class MarkForDeletion(object):
         return self._reporter
 
     @reporter.setter
-    def reporter(self, value: str) -> None:
+    def reporter(self, value: Optional[str]) -> None:
         """
         Sets the reporter
 

--- a/Modules/mark_for_deletion.py
+++ b/Modules/mark_for_deletion.py
@@ -18,7 +18,9 @@ class MarkForDeletion(object):
     Data object representing a MD structurefrom the API
     """
 
-    def __init__(self, marked: bool, reason: Optional[str], reporter: Optional[str]):
+    def __init__(self, marked: bool = False,
+                 reason: Optional[str] = None,
+                 reporter: Optional[str] = None):
         """
         Creates a new MD object
 
@@ -61,7 +63,7 @@ class MarkForDeletion(object):
             raise TypeError
 
     @property
-    def reason(self) -> str:
+    def reason(self) -> Optional[str]:
         """
         Reported reason for marking the case as deleted
 
@@ -84,13 +86,13 @@ class MarkForDeletion(object):
         Raises:
             TypeError: invalid type
         """
-        if isinstance(value, str):
+        if isinstance(value, str) or value is None:
             self._reason = value
         else:
             raise TypeError
 
     @property
-    def reporter(self) -> str:
+    def reporter(self) -> Optional[str]:
         """
         IRC nickname of reporting user
 
@@ -113,7 +115,7 @@ class MarkForDeletion(object):
         Raises:
             TypeError: invalid type
         """
-        if isinstance(value, str):
+        if isinstance(value, str) or value is None:
             self._reporter = value
         else:
             raise TypeError

--- a/Modules/rat_rescue.py
+++ b/Modules/rat_rescue.py
@@ -19,6 +19,7 @@ from typing import Union, Optional, List
 from uuid import UUID
 
 from Modules.epic import Epic
+from Modules.mark_for_deletion import MarkForDeletion
 from Modules.rat_quotation import Quotation
 from Modules.rats import Rats
 from utils.ratlib import Platforms, Status
@@ -43,11 +44,11 @@ class Rescue(object):
                  quotes: list = None,
                  epic: List[Epic] = None,
                  title: Optional[str] = None,
-                 first_limpet: Optional[UUID]= None,
+                 first_limpet: Optional[UUID] = None,
                  board_index: Optional[int] = None,
-                 mark_for_deletion: Optional[dict]= None,
+                 mark_for_deletion: MarkForDeletion = None,
                  lang_id: str = "EN",
-                 rats: list = None,
+                 rats: List[Rats] = None,
                  status: Status = Status.OPEN,
                  code_red=False):
         """
@@ -99,11 +100,7 @@ class Rescue(object):
         self._title: Union[str, None] = title
         self._firstLimpet: UUID = first_limpet
         self._board_index = board_index
-        self._mark_for_deletion = mark_for_deletion if mark_for_deletion else {
-            "marked": False,
-            "reason": None,
-            "reporter": None
-        }
+        self._mark_for_deletion = mark_for_deletion
         self._board_index = board_index
         self._lang_id = lang_id
         self._status = status
@@ -699,30 +696,13 @@ class Rescue(object):
             TypeError: bad value type
             ValueError: value failed validation
         """
-        if isinstance(value, dict):
-            # checks to ensure only the required fields are present
-            if "marked" in value and "reason" in value and "reporter" in value and len(value) == 3:
-                # now sanity check the values
-                conditions = {
-                    isinstance(value["marked"], bool),
-                    isinstance(value["reason"], str) or value["reason"] is None,
-                    isinstance(value["reporter"], str) or value["reporter"] is None,
-                }
-                if all(conditions):
-                    self._mark_for_deletion = value
-
-                else:
-                    # at least one of the values was not valid
-                    raise ValueError("Data validation failed. at least one key contains invalid"
-                                     "data.")
-            else:
-                log.debug(f"Data of value is: {value}")
-                raise ValueError("required fields missing and/or keys!")
+        if isinstance(value, MarkForDeletion):
+            self._mark_for_deletion = value
         else:
-            raise TypeError(f"expected type dict, got type {type(value)}")
+            raise TypeError
 
     @property
-    def rats(self) -> list:
+    def rats(self) -> List[Rats]:
         """
         Identified rats assigned to rescue
 

--- a/Modules/rat_rescue.py
+++ b/Modules/rat_rescue.py
@@ -785,12 +785,11 @@ class Rescue(object):
                 rat = Rats(name=name, uuid=guid)
                 self.rats.append(rat)
 
-    def mark(self, marked: bool, reporter: str, reason: str):
+    def mark_delete(self, reporter: str, reason: str) -> None:
         """
-        Marks or unmarks a rescue for deletion
+        Marks a rescue for deletion
 
         Args:
-            marked (bool): bool marking whether to mark or remove the Md mark
             reporter (str): person marking rescue as deleted
             reason (str): reason for the rescue being marked as deleted.
 
@@ -798,26 +797,25 @@ class Rescue(object):
             TypeError: invalid params
         """
         # type enforcement
-        if not isinstance(marked, bool) or not isinstance(reporter, str) or not isinstance(reason,
-                                                                                           str):
+        if not isinstance(reporter, str) or not isinstance(reason, str):
             raise TypeError
 
-        if marked:  # mark the rescue for deletion
-            log.debug(f"marking rescue @{self.case_id} for deletion. reporter is {reporter} and "
-                      f"their reason is '{reason}'.")
-            if reason == "":
-                raise ValueError("Reason required.")
-            self.mark_for_deletion.reporter = reporter
-            self.mark_for_deletion.reason = reason
-            self.mark_for_deletion.marked = True
+        log.debug(f"marking rescue @{self.case_id} for deletion. reporter is {reporter} and "
+                  f"their reason is '{reason}'.")
+        if reason == "":
+            raise ValueError("Reason required.")
+        self.mark_for_deletion.reporter = reporter
+        self.mark_for_deletion.reason = reason
+        self.mark_for_deletion.marked = True
 
-        else:  # unmark the rescue for deletion
-            log.debug(f"clearing Md status for rescue @{self.case_id} ...")
-            self.mark_for_deletion.reason = None
-            self.mark_for_deletion.reporter = None
-            self.mark_for_deletion.marked = False
+    def unmark_delete(self) -> None:
+        """
+        helper method for unmarking a rescue for deletion. resets the Md object
+        """
 
-
+        self.mark_for_deletion.marked = False
+        self.mark_for_deletion.reason = None
+        self.mark_for_deletion.reporter = None
 
     @contextmanager
     def change(self):

--- a/Modules/rat_rescue.py
+++ b/Modules/rat_rescue.py
@@ -18,7 +18,6 @@ from operator import xor
 from typing import Union, Optional, List
 from uuid import UUID
 
-from Modules.context import Context
 from Modules.epic import Epic
 from Modules.mark_for_deletion import MarkForDeletion
 from Modules.rat_quotation import Quotation
@@ -786,24 +785,24 @@ class Rescue(object):
                 rat = Rats(name=name, uuid=guid)
                 self.rats.append(rat)
 
-    def mark(self, marked: bool, context: Context):
+    def mark(self, marked: bool, reporter: str, reason: str):
         """
         Marks or unmarks a rescue for deletion
 
         Args:
             marked (bool): bool marking whether to mark or remove the Md mark
-            context (Context): Command context of invocation
+            reporter (str): person marking rescue as deleted
+            reason (str): reason for the rescue being marked as deleted.
 
         Raises:
-            AssertionError: invalid params
+            TypeError: invalid params
         """
         # type enforcement
-        assert isinstance(marked, bool), "invalid marked value"
-        assert isinstance(context, Context), "invalid context object"
+        if not isinstance(marked, bool) or not isinstance(reporter, str) or not isinstance(reason,
+                                                                                           str):
+            raise TypeError
 
         if marked:  # mark the rescue for deletion
-            reporter = context.user.nickname
-            reason = context.words_eol[1]
             log.debug(f"marking rescue @{self.case_id} for deletion. reporter is {reporter} and "
                       f"their reason is '{reason}'.")
             if reason == "":

--- a/Modules/rat_rescue.py
+++ b/Modules/rat_rescue.py
@@ -138,7 +138,7 @@ class Rescue(object):
                 self.outcome == other.outcome,
                 self.title == other.title,
                 self.first_limpet == other.first_limpet,
-                self.mark_for_deletion == other.mark_for_deletion,
+                self.marked_for_deletion == other.marked_for_deletion,
                 self.lang_id == other.lang_id,
                 self.rats == other.rats,
                 self.irc_nickname == other.irc_nickname,
@@ -672,7 +672,7 @@ class Rescue(object):
             raise TypeError(f"expected type None or str, got {type(value)}")
 
     @property
-    def mark_for_deletion(self) -> MarkForDeletion:
+    def marked_for_deletion(self) -> MarkForDeletion:
         """
         Mark for deletion object as used by the API
 
@@ -681,8 +681,8 @@ class Rescue(object):
         """
         return self._mark_for_deletion
 
-    @mark_for_deletion.setter
-    def mark_for_deletion(self, value) -> None:
+    @marked_for_deletion.setter
+    def marked_for_deletion(self, value) -> None:
         """
         Sets the Md object
 
@@ -804,18 +804,18 @@ class Rescue(object):
                   f"their reason is '{reason}'.")
         if reason == "":
             raise ValueError("Reason required.")
-        self.mark_for_deletion.reporter = reporter
-        self.mark_for_deletion.reason = reason
-        self.mark_for_deletion.marked = True
+        self.marked_for_deletion.reporter = reporter
+        self.marked_for_deletion.reason = reason
+        self.marked_for_deletion.marked = True
 
     def unmark_delete(self) -> None:
         """
         helper method for unmarking a rescue for deletion. resets the Md object
         """
 
-        self.mark_for_deletion.marked = False
-        self.mark_for_deletion.reason = None
-        self.mark_for_deletion.reporter = None
+        self.marked_for_deletion.marked = False
+        self.marked_for_deletion.reason = None
+        self.marked_for_deletion.reporter = None
 
     @contextmanager
     def change(self):

--- a/Modules/rat_rescue.py
+++ b/Modules/rat_rescue.py
@@ -699,7 +699,7 @@ class Rescue(object):
         if isinstance(value, MarkForDeletion):
             self._mark_for_deletion = value
         else:
-            raise TypeError
+            raise TypeError(f"got {type(value)} expected MarkForDeletion object")
 
     @property
     def rats(self) -> List[Rats]:
@@ -798,7 +798,8 @@ class Rescue(object):
         """
         # type enforcement
         if not isinstance(reporter, str) or not isinstance(reason, str):
-            raise TypeError
+            raise TypeError(f"reporter and/or reason of invalid type. got {type(reporter)},"
+                            f"{type(reason)}")
 
         log.debug(f"marking rescue @{self.case_id} for deletion. reporter is {reporter} and "
                   f"their reason is '{reason}'.")

--- a/Modules/rat_rescue.py
+++ b/Modules/rat_rescue.py
@@ -793,9 +793,13 @@ class Rescue(object):
         Args:
             marked (bool): bool marking whether to mark or remove the Md mark
             context (Context): Command context of invocation
+
+        Raises:
+            AssertionError: invalid params
         """
         # type enforcement
         assert isinstance(marked, bool), "invalid marked value"
+        assert isinstance(context, Context), "invalid context object"
 
         if marked:  # mark the rescue for deletion
             reporter = context.user.nickname
@@ -808,7 +812,8 @@ class Rescue(object):
             self.mark_for_deletion.reason = reason
             self.mark_for_deletion.marked = True
 
-        else:
+        else:  # unmark the rescue for deletion
+            log.debug(f"clearing Md status for rescue @{self.case_id} ...")
             self.mark_for_deletion.reason = None
             self.mark_for_deletion.reporter = None
             self.mark_for_deletion.marked = False

--- a/Modules/rat_rescue.py
+++ b/Modules/rat_rescue.py
@@ -46,7 +46,7 @@ class Rescue(object):
                  title: Optional[str] = None,
                  first_limpet: Optional[UUID] = None,
                  board_index: Optional[int] = None,
-                 mark_for_deletion: MarkForDeletion = None,
+                 mark_for_deletion: MarkForDeletion = MarkForDeletion(),
                  lang_id: str = "EN",
                  rats: List[Rats] = None,
                  status: Status = Status.OPEN,
@@ -672,7 +672,7 @@ class Rescue(object):
             raise TypeError(f"expected type None or str, got {type(value)}")
 
     @property
-    def mark_for_deletion(self) -> dict:
+    def mark_for_deletion(self) -> MarkForDeletion:
         """
         Mark for deletion object as used by the API
 

--- a/Modules/rat_rescue.py
+++ b/Modules/rat_rescue.py
@@ -18,6 +18,7 @@ from operator import xor
 from typing import Union, Optional, List
 from uuid import UUID
 
+from Modules.context import Context
 from Modules.epic import Epic
 from Modules.mark_for_deletion import MarkForDeletion
 from Modules.rat_quotation import Quotation
@@ -784,6 +785,35 @@ class Rescue(object):
 
                 rat = Rats(name=name, uuid=guid)
                 self.rats.append(rat)
+
+    def mark(self, marked: bool, context: Context):
+        """
+        Marks or unmarks a rescue for deletion
+
+        Args:
+            marked (bool): bool marking whether to mark or remove the Md mark
+            context (Context): Command context of invocation
+        """
+        # type enforcement
+        assert isinstance(marked, bool), "invalid marked value"
+
+        if marked:  # mark the rescue for deletion
+            reporter = context.user.nickname
+            reason = context.words_eol[1]
+            log.debug(f"marking rescue @{self.case_id} for deletion. reporter is {reporter} and "
+                      f"their reason is '{reason}'.")
+            if reason == "":
+                raise ValueError("Reason required.")
+            self.mark_for_deletion.reporter = reporter
+            self.mark_for_deletion.reason = reason
+            self.mark_for_deletion.marked = True
+
+        else:
+            self.mark_for_deletion.reason = None
+            self.mark_for_deletion.reporter = None
+            self.mark_for_deletion.marked = False
+
+
 
     @contextmanager
     def change(self):

--- a/tests/test_rescue.py
+++ b/tests/test_rescue.py
@@ -18,7 +18,7 @@ from uuid import uuid4
 
 import pytest
 
-from Modules.context import Context
+from Modules.mark_for_deletion import MarkForDeletion
 from Modules.rat_rescue import Rescue
 from Modules.rats import Rats
 from utils.ratlib import Platforms
@@ -637,19 +637,29 @@ class TestRescuePyTests(object):
     @pytest.mark.parametrize("reporter, reason", [("unit_test[BOT]", "reasons! reasons i say!"),
                                                   ("potato[pc|nd]", "uhhh..."),
                                                   ("sayWhat99", "dawg this ain't right!")])
-    def test_mark_true_valid(self, rescue_sop_fx: Rescue, reporter: str, reason: str):
+    def test_mark_delete_valid(self, rescue_sop_fx: Rescue, reporter: str, reason: str):
         """Verifies Rescue.mark functions as expected when marking a case for deletion"""
 
-        rescue_sop_fx.mark(True, reporter, reason)
+        rescue_sop_fx.mark_delete(reporter, reason)
 
         assert rescue_sop_fx.mark_for_deletion.marked
         assert reporter == rescue_sop_fx.mark_for_deletion.reporter
         assert reason == rescue_sop_fx.mark_for_deletion.reason
 
-    def test_mark_true_invalid(self, rescue_sop_fx: Rescue, context_fx: Context):
+    def test_mark_delete_invalid(self, rescue_sop_fx: Rescue):
         """verify what happens when garbage gets thrown at `rescue.mark`"""
         with pytest.raises(TypeError):
-            rescue_sop_fx.mark(True, None, None)
+            rescue_sop_fx.mark_delete(None, "sna")
 
         with pytest.raises(TypeError):
-            rescue_sop_fx.mark("True", context_fx)
+            rescue_sop_fx.mark_delete("sna", None)
+
+    def test(self, rescue_sop_fx: Rescue):
+        """Verify unmarking a case that was MD'ed works as expected"""
+        rescue_sop_fx.mark_for_deletion = MarkForDeletion(True, "unit_test[BOT]",
+                                                          "unit test reasons!")
+
+        rescue_sop_fx.unmark_delete()
+        assert rescue_sop_fx.mark_for_deletion.marked is False
+        assert rescue_sop_fx.mark_for_deletion.reporter is None
+        assert rescue_sop_fx.mark_for_deletion.reason is None

--- a/tests/test_rescue.py
+++ b/tests/test_rescue.py
@@ -657,3 +657,11 @@ class TestRescuePyTests(object):
         assert rescue_sop_fx.mark_for_deletion.marked
         assert user_fx.nickname == rescue_sop_fx.mark_for_deletion.reporter
         assert context.words_eol[1] == rescue_sop_fx.mark_for_deletion.reason
+
+    def test_mark_true_invalid(self, rescue_sop_fx: Rescue, context_fx: Context):
+        """verify what happens when garbage gets thrown at `rescue.mark`"""
+        with pytest.raises(AssertionError):
+            rescue_sop_fx.mark(True, None)
+
+        with pytest.raises(AssertionError):
+            rescue_sop_fx.mark("True", context_fx)

--- a/tests/test_rescue.py
+++ b/tests/test_rescue.py
@@ -654,6 +654,9 @@ class TestRescuePyTests(object):
         with pytest.raises(TypeError):
             rescue_sop_fx.mark_delete("sna", None)
 
+        with pytest.raises(ValueError):
+            rescue_sop_fx.mark_delete("unit_test", "")
+
     def test(self, rescue_sop_fx: Rescue):
         """Verify unmarking a case that was MD'ed works as expected"""
         rescue_sop_fx.mark_for_deletion = MarkForDeletion(True, "unit_test[BOT]",

--- a/tests/test_rescue.py
+++ b/tests/test_rescue.py
@@ -542,50 +542,46 @@ class TestRescuePyTests(object):
         (None, None, True),
         (None, None, False)
     ])
-    def test_mark_for_deletion_setter_good_data(self, reason: str or None, reporter: str or None,
-                                                marked: bool, rescue_plain_fx: Rescue):
-        """
-        Verifies setting the mark for deletion property succeeds when the data is valid
+    def test_mark_for_deletion_setter_valid(self, rescue_sop_fx: Rescue, reason: str, reporter: str,
+                                            marked: bool):
+        rescue_sop_fx.mark_for_deletion.reporter = reporter
+        assert rescue_sop_fx.mark_for_deletion.reporter == reporter
 
-        Args:
-            rescue_plain_fx (): plain rescue fixture
-            reason (str): md reason
-            reporter(str) md reporter
-        """
+        rescue_sop_fx.mark_for_deletion.reason = reason
+        assert rescue_sop_fx.mark_for_deletion.reason == reason
 
-        myMdStructure = {
-            "marked": marked,
-            "reason": reason,
-            "reporter": reporter
-        }
-        rescue_plain_fx.mark_for_deletion = myMdStructure
-        assert myMdStructure == rescue_plain_fx.mark_for_deletion
+        rescue_sop_fx.mark_for_deletion.reporter = reporter
+        assert rescue_sop_fx.mark_for_deletion.reporter == reporter
+
 
     @pytest.mark.parametrize("reason,reporter,marked", [
-        ("some reason", 42, True),
-        (-2.1, "Potato", False),
-        (None, None, 0),
-        (True, None, False)
+        ([], 42.2, -1),
+        (-2.1, {"Potato"}, None),
+        ([], 42, "md reason"),
+        (True, -42.2, uuid4())
     ])
     def test_mark_for_deletion_setter_bad_data(self, reason: str or None, reporter: str or None,
-                                               marked: bool, rescue_plain_fx: Rescue):
+                                               marked: bool, rescue_sop_fx: Rescue):
         """
         Verifies setting the mark for deletion property succeeds when the data is valid
 
         Args:
-            rescue_plain_fx (): plain rescue fixture
+            rescue_sop_fx (): plain rescue fixture
             reason (str): md reason
             reporter(str) md reporter
         """
+        with pytest.raises(TypeError):
+            rescue_sop_fx.mark_for_deletion.reason = reason
 
-        my_md_structure = {
-            "marked": marked,
-            "reason": reason,
-            "reporter": reporter
-        }
-        with pytest.raises(ValueError):
-            rescue_plain_fx.mark_for_deletion = my_md_structure
-            assert my_md_structure != rescue_plain_fx.mark_for_deletion
+        with pytest.raises(TypeError):
+            rescue_sop_fx.mark_for_deletion.reporter = reporter
+
+        with pytest.raises(TypeError):
+            rescue_sop_fx.mark_for_deletion.marked = marked
+
+        assert rescue_sop_fx.mark_for_deletion.marked is False
+        assert rescue_sop_fx.mark_for_deletion.reason != reason
+        assert rescue_sop_fx.mark_for_deletion.reporter != reporter
 
     @pytest.mark.parametrize("garbage", [None, 42, -2.2, []])
     def test_mark_for_deletion_setter_bad_types(self, garbage, rescue_plain_fx: Rescue):
@@ -593,18 +589,6 @@ class TestRescuePyTests(object):
         myRescue = deepcopy(rescue_plain_fx)
 
         with pytest.raises(TypeError):
-            myRescue.mark_for_deletion = garbage
-
-    @pytest.mark.parametrize("garbage", [
-        {'reason': 42, 'marked': True, 'reporter': "UNIT_TEST"},
-        {'reason': None, "marked": 1, 'reporter': "UNIT_TEST"},
-        {'reason': None, "marked": False, "reporter": 21}
-    ])
-    def test_mark_for_deletion_setter_malformed_data(self, garbage, rescue_plain_fx: Rescue):
-        """Verifies attempting to set Rescue.mark_for_deletion to bad types results in a TypeError"""
-        myRescue = deepcopy(rescue_plain_fx)
-
-        with pytest.raises(ValueError):
             myRescue.mark_for_deletion = garbage
 
     @pytest.mark.asyncio

--- a/tests/test_rescue.py
+++ b/tests/test_rescue.py
@@ -12,7 +12,6 @@ This module is built on top of the Pydle system.
 """
 from copy import deepcopy
 from datetime import datetime
-from typing import List
 from unittest import TestCase
 from unittest.mock import patch, MagicMock
 from uuid import uuid4
@@ -22,7 +21,6 @@ import pytest
 from Modules.context import Context
 from Modules.rat_rescue import Rescue
 from Modules.rats import Rats
-from Modules.user import User
 from utils.ratlib import Platforms
 
 
@@ -636,32 +634,22 @@ class TestRescuePyTests(object):
         """
         assert not rescue_plain_fx == "Rescue object at <0xBADBEEF> "
 
-    @pytest.mark.parametrize("words, words_eol", [
-        (["md", "3", "I", "have", "my", "reasons!"],
-         ["3 I have my reasons!", "I have my reasons!", "have my reasons!",
-          "my reasons!", "reasons!"]),
-        (["md", "4", "reasons"], ["md 4 reasons", "4 reasons", "reasons"])
-    ])
-    def test_mark_true_valid(self, rescue_sop_fx: Rescue,
-                             bot_fx,
-                             user_fx: User,
-                             words: List[str],
-                             words_eol: List[str]):
+    @pytest.mark.parametrize("reporter, reason", [("unit_test[BOT]", "reasons! reasons i say!"),
+                                                  ("potato[pc|nd]", "uhhh..."),
+                                                  ("sayWhat99", "dawg this ain't right!")])
+    def test_mark_true_valid(self, rescue_sop_fx: Rescue, reporter: str, reason: str):
         """Verifies Rescue.mark functions as expected when marking a case for deletion"""
 
-        context = Context(bot_fx,
-                          user_fx,
-                          "#unit_test", words, words_eol)
+        rescue_sop_fx.mark(True, reporter, reason)
 
-        rescue_sop_fx.mark(True, context)
         assert rescue_sop_fx.mark_for_deletion.marked
-        assert user_fx.nickname == rescue_sop_fx.mark_for_deletion.reporter
-        assert context.words_eol[1] == rescue_sop_fx.mark_for_deletion.reason
+        assert reporter == rescue_sop_fx.mark_for_deletion.reporter
+        assert reason == rescue_sop_fx.mark_for_deletion.reason
 
     def test_mark_true_invalid(self, rescue_sop_fx: Rescue, context_fx: Context):
         """verify what happens when garbage gets thrown at `rescue.mark`"""
-        with pytest.raises(AssertionError):
-            rescue_sop_fx.mark(True, None)
+        with pytest.raises(TypeError):
+            rescue_sop_fx.mark(True, None, None)
 
-        with pytest.raises(AssertionError):
+        with pytest.raises(TypeError):
             rescue_sop_fx.mark("True", context_fx)

--- a/tests/test_rescue.py
+++ b/tests/test_rescue.py
@@ -545,14 +545,14 @@ class TestRescuePyTests(object):
     ])
     def test_mark_for_deletion_setter_valid(self, rescue_sop_fx: Rescue, reason: str, reporter: str,
                                             marked: bool):
-        rescue_sop_fx.mark_for_deletion.reporter = reporter
-        assert rescue_sop_fx.mark_for_deletion.reporter == reporter
+        rescue_sop_fx.marked_for_deletion.reporter = reporter
+        assert rescue_sop_fx.marked_for_deletion.reporter == reporter
 
-        rescue_sop_fx.mark_for_deletion.reason = reason
-        assert rescue_sop_fx.mark_for_deletion.reason == reason
+        rescue_sop_fx.marked_for_deletion.reason = reason
+        assert rescue_sop_fx.marked_for_deletion.reason == reason
 
-        rescue_sop_fx.mark_for_deletion.reporter = reporter
-        assert rescue_sop_fx.mark_for_deletion.reporter == reporter
+        rescue_sop_fx.marked_for_deletion.reporter = reporter
+        assert rescue_sop_fx.marked_for_deletion.reporter == reporter
 
 
     @pytest.mark.parametrize("reason,reporter,marked", [
@@ -572,17 +572,17 @@ class TestRescuePyTests(object):
             reporter(str) md reporter
         """
         with pytest.raises(TypeError):
-            rescue_sop_fx.mark_for_deletion.reason = reason
+            rescue_sop_fx.marked_for_deletion.reason = reason
 
         with pytest.raises(TypeError):
-            rescue_sop_fx.mark_for_deletion.reporter = reporter
+            rescue_sop_fx.marked_for_deletion.reporter = reporter
 
         with pytest.raises(TypeError):
-            rescue_sop_fx.mark_for_deletion.marked = marked
+            rescue_sop_fx.marked_for_deletion.marked = marked
 
-        assert rescue_sop_fx.mark_for_deletion.marked is False
-        assert rescue_sop_fx.mark_for_deletion.reason != reason
-        assert rescue_sop_fx.mark_for_deletion.reporter != reporter
+        assert rescue_sop_fx.marked_for_deletion.marked is False
+        assert rescue_sop_fx.marked_for_deletion.reason != reason
+        assert rescue_sop_fx.marked_for_deletion.reporter != reporter
 
     @pytest.mark.parametrize("garbage", [None, 42, -2.2, []])
     def test_mark_for_deletion_setter_bad_types(self, garbage, rescue_plain_fx: Rescue):
@@ -590,7 +590,7 @@ class TestRescuePyTests(object):
         myRescue = deepcopy(rescue_plain_fx)
 
         with pytest.raises(TypeError):
-            myRescue.mark_for_deletion = garbage
+            myRescue.marked_for_deletion = garbage
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("uuid,name", [(uuid4(), "foo"), (uuid4(), "bar"), (uuid4(), "potato")])
@@ -642,9 +642,9 @@ class TestRescuePyTests(object):
 
         rescue_sop_fx.mark_delete(reporter, reason)
 
-        assert rescue_sop_fx.mark_for_deletion.marked
-        assert reporter == rescue_sop_fx.mark_for_deletion.reporter
-        assert reason == rescue_sop_fx.mark_for_deletion.reason
+        assert rescue_sop_fx.marked_for_deletion.marked
+        assert reporter == rescue_sop_fx.marked_for_deletion.reporter
+        assert reason == rescue_sop_fx.marked_for_deletion.reason
 
     def test_mark_delete_invalid(self, rescue_sop_fx: Rescue):
         """verify what happens when garbage gets thrown at `rescue.mark`"""
@@ -659,10 +659,10 @@ class TestRescuePyTests(object):
 
     def test(self, rescue_sop_fx: Rescue):
         """Verify unmarking a case that was MD'ed works as expected"""
-        rescue_sop_fx.mark_for_deletion = MarkForDeletion(True, "unit_test[BOT]",
+        rescue_sop_fx.marked_for_deletion = MarkForDeletion(True, "unit_test[BOT]",
                                                           "unit test reasons!")
 
         rescue_sop_fx.unmark_delete()
-        assert rescue_sop_fx.mark_for_deletion.marked is False
-        assert rescue_sop_fx.mark_for_deletion.reporter is None
-        assert rescue_sop_fx.mark_for_deletion.reason is None
+        assert rescue_sop_fx.marked_for_deletion.marked is False
+        assert rescue_sop_fx.marked_for_deletion.reporter is None
+        assert rescue_sop_fx.marked_for_deletion.reason is None


### PR DESCRIPTION
This PR reimplements `Rescue.mark_for_deletion`, giving it its own data structure `MarkForDelete`.

Most of our complex data structures now exist as Class objects, such as `User`, `Rats`, and `Quotation`.
Therefore, i reason, it is about time we do the same for MarkForDeletion.

Doing it this way better separates the API from Mecha's runtime, as the API would be able to change the background structure of the object without requiring significant change to Mechasqueak itself, but rather its API driver. 

This change also contributes to documentation and ease-of development as many IDEs find it easier to provide completions for Class objects than for dictionary entries.

Introduced class:
----------------
`MarkForDelete`

## instance attributes:
`marked`: bool, indicates if the rescue is marked for deletion
`reporter`: str, irc nickname of MD'ing user
`reason`: str reason for marking rescue as MD


Introduced helper methods in `Rescue`
----------------------
`Rescue.mark_delete` marks a case for deletion, requires author and a reason.
`Rescue.unmark_delete` unmarks a case as MD'ed.

Feedback on method naming would be appreciated


Checklist:
- [x] MarkForDeletion
- [x] Rescue refactoring
- [x] Rescue helper methods
- [x] tests
- [x] documentation 