### PR TITLE
SPARK-40: Include doctests in tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
           command: |
             . venv/bin/activate
             ./cc-test-reporter before-build
-            pytest -v --cov --cov-report xml --junit-xml=test-reports
+            pytest -v --cov --cov-report xml --junit-xml=test-reports --doctest-modules
             ./cc-test-reporter after-build --coverage-input-type coverage.py --exit-code $?
 
       - store_artifacts:


### PR DESCRIPTION
This PR simply adds the `--doctest-modules` cli flag to the circleci test command.