### PR TITLE
SPARK-39: MD `__eq__` and `__hash__` methods

### DIFF
--- a/Modules/mark_for_deletion.py
+++ b/Modules/mark_for_deletion.py
@@ -10,6 +10,8 @@ Licensed under the BSD 3-Clause License.
 
 See LICENSE.md
 """
+from functools import reduce
+from operator import xor
 from typing import Optional
 
 
@@ -31,6 +33,7 @@ class MarkForDeletion(object):
         self._reporter = reporter
         self._marked = marked
         self._reason = reason
+        self._hash = None
 
     def __eq__(self, other: 'MarkForDeletion') -> bool:
         if not isinstance(other, MarkForDeletion):
@@ -42,6 +45,18 @@ class MarkForDeletion(object):
             self.marked == other.marked
         )
         return all(conditions)
+
+    def __hash__(self):
+
+        if self._hash is None:
+            attributes = (
+                self.marked,
+                self.reason,
+                self.reporter
+            )
+
+            self._hash = reduce(xor, map(hash, attributes))
+        return self._hash
 
     @property
     def marked(self) -> bool:

--- a/Modules/mark_for_deletion.py
+++ b/Modules/mark_for_deletion.py
@@ -32,6 +32,17 @@ class MarkForDeletion(object):
         self._marked = marked
         self._reason = reason
 
+    def __eq__(self, other: 'MarkForDeletion') -> bool:
+        if not isinstance(other, MarkForDeletion):
+            return NotImplemented
+
+        conditions = (
+            self.reason == other.reason,
+            self.reporter == other.reporter,
+            self.marked == other.marked
+        )
+        return all(conditions)
+
     @property
     def marked(self) -> bool:
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,10 +11,10 @@ Licensed under the BSD 3-Clause License.
 
 See LICENSE
 """
-import sys
-import string
 import logging
 import random
+import string
+import sys
 from uuid import uuid4, UUID
 
 import pytest
@@ -28,6 +28,7 @@ sys.argv = ["test",
 
 # This import statement is where the config gets read
 from config import setup_logging
+
 setup_logging("logs/unit_tests.log")
 
 from tests.mock_bot import MockBot
@@ -39,6 +40,7 @@ from Modules.context import Context
 from Modules.epic import Epic
 from Modules.user import User
 from Modules.mark_for_deletion import MarkForDeletion
+
 
 @pytest.fixture(params=[("pcClient", Platforms.PC, "firestone", 24),
                         ("xxXclient", Platforms.XB, "sol", 2),
@@ -170,6 +172,7 @@ def logging_fx(caplog) -> logging.Logger:
     """
     caplog.clear()
     return logging.getLogger("mecha.logging_fx")
+
 
 @pytest.fixture
 def random_string_fx() -> str:

--- a/tests/test_mark_for_deletion.py
+++ b/tests/test_mark_for_deletion.py
@@ -1,0 +1,72 @@
+"""
+test_mark_for_deletion.py - tests for MarkForDeletion
+
+Copyright (c) 2018 The Fuel Rats Mischief,
+All rights reserved.
+
+Licensed under the BSD 3-Clause License.
+
+See LICENSE.md
+
+This module is built on top of the Pydle system.
+"""
+from typing import Optional
+from uuid import uuid4
+
+import pytest
+
+from Modules.mark_for_deletion import MarkForDeletion
+
+
+@pytest.mark.parametrize("reason,reporter,marked", [
+    ([], 42.2, -1),
+    (-2.1, {"Potato"}, None),
+    ([], 42, "md reason"),
+    (True, -42.2, uuid4())
+])
+def test_mark_for_deletion_setter_bad_data(reason: str or None, reporter: str or None,
+                                           marked: bool, mark_for_deletion_fx: MarkForDeletion):
+    """
+    Verifies setting the mark for deletion property succeeds when the data is valid
+
+        Args:
+            rescue_sop_fx (): plain rescue fixture
+            reason (str): md reason
+            reporter(str) md reporter
+    """
+    with pytest.raises(TypeError):
+        mark_for_deletion_fx.reason = reason
+
+    with pytest.raises(TypeError):
+        mark_for_deletion_fx.reporter = reporter
+
+    with pytest.raises(TypeError):
+        mark_for_deletion_fx.marked = marked
+
+    assert isinstance(mark_for_deletion_fx.marked, bool)
+    assert mark_for_deletion_fx.reason != reason
+    assert mark_for_deletion_fx.reporter != reporter
+
+
+@pytest.mark.parametrize("marked,reason,reporter", [(False, None, None),
+                                                    (True, "what could possibly go wrong?",
+                                                     "cannonFodder"),
+                                                    (True, "whats this button do?", "unit_test")])
+def test_eq(marked: bool, reason: Optional[str], reporter: Optional[str]):
+    md_a = MarkForDeletion(marked, reporter, reason)
+    md_b = MarkForDeletion(marked, reporter, reason)
+    assert md_a == md_b
+
+
+@pytest.mark.parametrize("data_a, data_b", [
+    ((False, None, None), (True, "smelly", "fart"),),
+    ((True, "reason", "unit_test"), (True, "no reason", "unit_test")),
+    ((True, "Reasons is say!", "clueless_user"), (True, "Reasons i say!", "helpful_sidewinder99"))
+])
+def test_ne(data_a, data_b):
+    marked_a, reason_a, reporter_a = data_a
+    md_a = MarkForDeletion(marked_a, reporter_a, reason_a)
+
+    marked_b, reason_b, reporter_b = data_b
+    md_b = MarkForDeletion(marked_b, reporter_b, reason_b)
+    assert md_a != md_b

--- a/tests/test_mark_for_deletion.py
+++ b/tests/test_mark_for_deletion.py
@@ -58,6 +58,11 @@ def test_eq(marked: bool, reason: Optional[str], reporter: Optional[str]):
     assert md_a == md_b
 
 
+@pytest.mark.parametrize("garbage", [None, -1, [], "pft"])
+def test_eq_garbage(garbage, mark_for_deletion_fx):
+    assert not mark_for_deletion_fx == garbage
+
+
 @pytest.mark.parametrize("data_a, data_b", [
     ((False, None, None), (True, "smelly", "fart"),),
     ((True, "reason", "unit_test"), (True, "no reason", "unit_test")),

--- a/tests/test_mark_for_deletion.py
+++ b/tests/test_mark_for_deletion.py
@@ -70,3 +70,7 @@ def test_ne(data_a, data_b):
     marked_b, reason_b, reporter_b = data_b
     md_b = MarkForDeletion(marked_b, reporter_b, reason_b)
     assert md_a != md_b
+
+
+def test_hash(mark_for_deletion_fx):
+    assert hash(mark_for_deletion_fx) != 0

--- a/tests/test_mark_for_deletion.py
+++ b/tests/test_mark_for_deletion.py
@@ -30,7 +30,6 @@ def test_mark_for_deletion_setter_bad_data(reason: str or None, reporter: str or
     Verifies setting the mark for deletion property succeeds when the data is valid
 
         Args:
-            rescue_sop_fx (): plain rescue fixture
             reason (str): md reason
             reporter(str) md reporter
     """
@@ -77,5 +76,34 @@ def test_ne(data_a, data_b):
     assert md_a != md_b
 
 
-def test_hash(mark_for_deletion_fx):
+def test_hash_nonzero(mark_for_deletion_fx):
     assert hash(mark_for_deletion_fx) != 0
+
+
+@pytest.mark.parametrize("alpha, beta", [
+    ((False, None, None), (False, None, None)),
+    ((True, "Unit_test", "reasons!"), (True, "Unit_test", "reasons!")),
+    ((True, "potato", "pft!"), (True, "potato", "pft!")),
+
+])
+def test_hash_equal(alpha, beta):
+    """ asserts two equal MD objects have the same hash."""
+
+    alpha = MarkForDeletion(*alpha)
+    beta = MarkForDeletion(*beta)
+
+    assert hash(alpha) == hash(beta)
+
+
+@pytest.mark.parametrize("alpha, beta", [
+    ((False, None, None), (True, None, None)),
+    ((True, "Unit_test", "reasons!"), (True, "potato", "reasons!")),
+    ((True, "potato", "uhh..."), (True, "potato", "pft!")),
+
+])
+def test_hash_unequal(alpha, beta):
+    """asserts two unequal Md objects do not have the same hash."""
+    alpha = MarkForDeletion(*alpha)
+    beta = MarkForDeletion(*beta)
+
+    assert hash(alpha) != hash(beta)

--- a/tests/test_mark_for_deletion.py
+++ b/tests/test_mark_for_deletion.py
@@ -27,7 +27,7 @@ from Modules.mark_for_deletion import MarkForDeletion
 def test_mark_for_deletion_setter_bad_data(reason: str or None, reporter: str or None,
                                            marked: bool, mark_for_deletion_fx: MarkForDeletion):
     """
-    Verifies setting the mark for deletion property succeeds when the data is valid
+    Verifies setting the mark for deletion property succeeds only when the data is valid
 
         Args:
             reason (str): md reason

--- a/tests/test_rescue.py
+++ b/tests/test_rescue.py
@@ -10,14 +10,15 @@ See LICENSE.md
 
 This module is built on top of the Pydle system.
 """
-import pytest
 from copy import deepcopy
 from datetime import datetime
 from uuid import uuid4, UUID
-from Modules.epic import Epic
+
+import pytest
+
 from Modules.mark_for_deletion import MarkForDeletion
-from Modules.rats import Rats
 from Modules.rat_rescue import Rescue
+from Modules.rats import Rats
 from utils.ratlib import Status
 
 
@@ -100,7 +101,7 @@ def test_updated_at_raises_typeerror(rescue_sop_fx):
     Verify Rescue.updated_at raises TypeError if given incorrect value,
     or is set to a date in the past.
     """
-    rescue_sop_fx._createdAt = datetime(1991, 1, 1, 1, 1, 1,)
+    rescue_sop_fx._createdAt = datetime(1991, 1, 1, 1, 1, 1, )
 
     # Set to a string time
     with pytest.raises(TypeError):
@@ -437,47 +438,6 @@ def test_set_unidentified_rats_incorrect_type(rescue_plain_fx: Rescue):
         rescue_plain_fx.unidentified_rats = 'Snozzberry, Wonka, Doc'
 
 
-@pytest.mark.parametrize("reason,reporter,marked", [
-    ([], 42.2, -1),
-    (-2.1, {"Potato"}, None),
-    ([], 42, "md reason"),
-    (True, -42.2, uuid4())
-])
-def test_mark_for_deletion_setter_bad_data(reason: str or None, reporter: str or None,
-                                           marked: bool, rescue_sop_fx: Rescue):
-    """
-    Verifies setting the mark for deletion property succeeds when the data is valid
-
-        Args:
-            rescue_sop_fx (): plain rescue fixture
-            reason (str): md reason
-            reporter(str) md reporter
-    """
-    with pytest.raises(TypeError):
-        rescue_sop_fx.marked_for_deletion.reason = reason
-
-    with pytest.raises(TypeError):
-        rescue_sop_fx.marked_for_deletion.reporter = reporter
-
-    with pytest.raises(TypeError):
-        rescue_sop_fx.marked_for_deletion.marked = marked
-
-    assert rescue_sop_fx.marked_for_deletion.marked is False
-    assert rescue_sop_fx.marked_for_deletion.reason != reason
-    assert rescue_sop_fx.marked_for_deletion.reporter != reporter
-
-
-@pytest.mark.parametrize("garbage", [None, 42, -2.2, []])
-def test_mark_for_deletion_setter_bad_types(garbage, rescue_plain_fx: Rescue):
-    """
-    Verifies attempting to set Rescue.mark_for_deletion to bad types results in a TypeError
-    """
-    result_rescue = deepcopy(rescue_plain_fx)
-
-    with pytest.raises(TypeError):
-        result_rescue.marked_for_deletion = garbage
-
-
 @pytest.mark.asyncio
 @pytest.mark.parametrize("uuid,name", [(uuid4(), "foo"), (uuid4(), "bar"), (uuid4(), "potato")])
 async def test_add_rat_by_rat_object(uuid: uuid4, name: str, rescue_plain_fx: Rescue):
@@ -553,7 +513,7 @@ def test_mark_delete_invalid(rescue_sop_fx: Rescue):
 
         with pytest.raises(ValueError):
             rescue_sop_fx.mark_delete("unit_test", "")
-            
+
 
 def test_mark_for_deletion_unset(rescue_sop_fx: Rescue):
     """
@@ -667,3 +627,14 @@ def test_rescue_code_red_setter(rescue_sop_fx):
 
     with pytest.raises(TypeError):
         rescue_sop_fx.code_red = 'Yes'
+
+
+@pytest.mark.parametrize("garbage", [None, 42, -2.2, []])
+def test_mark_for_deletion_setter_bad_types(garbage, rescue_plain_fx: Rescue):
+    """
+    Verifies attempting to set Rescue.mark_for_deletion to bad types results in a TypeError
+    """
+    result_rescue = deepcopy(rescue_plain_fx)
+
+    with pytest.raises(TypeError):
+        result_rescue.marked_for_deletion = garbage


### PR DESCRIPTION
this PR implements the missing `MarkForDeletion.__eq__` method.

As a supplement, i have also implemented a `__hash__` method for this object.