### PR TITLE
SPARK-53 fix silly @require_channel decorator requirement

### DIFF
--- a/Modules/permissions.py
+++ b/Modules/permissions.py
@@ -154,7 +154,7 @@ def require_channel(func: Union[str, Callable] = None,
         ... async def my_command(context: Context):
         ...     pass
     """
-    # form of @decorate("message")
+    # form of @decorator("message") and @decorator(message=str)
     if isinstance(func, str):
         message = func
 
@@ -202,25 +202,35 @@ def require_channel(func: Union[str, Callable] = None,
 
 # def require_dm(message: str = "command {cmd} must be invoked in a private message."):
 
-def require_dm(*args, **kwargs):
+def require_dm(func: Union[str, Callable] = None,
+               message: str = "This command must be invoked in a channel."):
     """
     Require the wrapped IRC command to be invoked in a DM context.
 
-    Usage:
-        ```py
-        @require_dm
-        async def my_command(context: Context):
-            pass
-        ```
-    """
-    func = None
-    # determine if the form is @require_channel(*args, **kwargs)
-    if len(args) == 1 and callable(args[0]):
-        # form is @require_dm(*args, **kwargs)
-        func = args[0]
+    Args:
+        func(Callable): wrapped function / access denied string override
+        message(str): access denied string
 
-    # fetch the `message` kwarg if it exists, default otherwise
-    message = kwargs.get("message", "this command must be invoked in a private message.")
+    Usage:
+        >>> @require_dm
+        ... async def my_command(context: Context):
+        ...     pass
+
+        >>> @require_dm("access denied.")
+        ... async def my_command(context: Context):
+        ...     pass
+
+        >>> @require_dm(message="access denied.")
+        ... async def my_command(context: Context):
+        ...     pass
+    """
+    # form of @decorator("message") and @decorator(message=str)
+    if isinstance(func, str):
+        message = func
+
+    # direct decoration
+    if not callable(func):
+        func = None
 
     def real_decorator(wrapped):
         """

--- a/Modules/permissions.py
+++ b/Modules/permissions.py
@@ -13,9 +13,7 @@ This module is built on top of the Pydle system.
 """
 import logging
 from functools import wraps
-
-from typing import Any, Union, Callable,List, Dict, Set
-
+from typing import Any, Union, Callable, List, Dict, Set
 
 from Modules.context import Context
 from config import config

--- a/Modules/permissions.py
+++ b/Modules/permissions.py
@@ -13,7 +13,7 @@ This module is built on top of the Pydle system.
 """
 import logging
 from functools import wraps
-from typing import Any
+from typing import Any, Union, Callable
 
 from Modules.context import Context
 
@@ -132,26 +132,35 @@ def require_permission(permission: Permission,
     return real_decorator
 
 
-def require_channel(*args, **kwargs):
+def require_channel(func: Union[str, Callable] = None,
+                    message: str = "This command must be invoked in a channel."):
     """
     Require the wrapped IRC command to be invoked in a channel context.
 
+    Args:
+        func(Union[str, Callable]): wrapped function / message
+        message(str): message to display on check fail
+
     Usage:
-        ```py
+        >>> @require_channel
+        ... async def my_command(context: Context):
+        ...     pass
 
-        @require_channel()
-        async def my_command(context: Context):
-            pass
-        ```
+        >>> @require_channel("access denied.")
+        ... async def my_command(context: Context):
+        ...     pass
+
+        >>> @require_channel(message="access denied.")
+        ... async def my_command(context: Context):
+        ...     pass
     """
-    func = None
-    # determine if the form is @require_channel(*args, **kwargs)
-    if len(args) == 1 and callable(args[0]):
-        # form is @require_channel(*args, **kwargs)
-        func = args[0]
+    # form of @decorate("message")
+    if isinstance(func, str):
+        message = func
 
-    # fetch the `message` kwarg if it exists, default otherwise
-    message = kwargs.get("message", "This command must be invoked in a channel.")
+    # direct decoration
+    if not callable(func):
+        func = None
 
     def real_decorator(wrapped):
         """

--- a/Modules/permissions.py
+++ b/Modules/permissions.py
@@ -183,7 +183,6 @@ def require_channel(*args, **kwargs):
                 await context.reply(message)
 
         return guarded
-    log.debug(f"wrapping function {func} with channel enforecement. messasge='{message}'")
     return real_decorator(func) if func else real_decorator
 
 

--- a/commands/debug.py
+++ b/commands/debug.py
@@ -20,7 +20,7 @@ log = logging.getLogger(f"mecha.{__name__}")
 
 
 @command("debug-whois")
-@require_channel()
+@require_channel
 @require_permission(TECHRAT)
 async def cmd_debug_whois(context):
     """A debug command for running a WHOIS command.

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -136,6 +136,8 @@ class TestPermissions(object):
 
     @pytest.mark.asyncio
     async def test_require_channel_valid(self, bot_fx, context_channel_fx):
+        """Verifies @require_channel does not stop commands invoked in a channel"""
+
         @require_channel(message="https://www.youtube.com/watch?v=gvdf5n-zI14")
         async def potato(context: Context):
             return "hi there!"
@@ -145,13 +147,77 @@ class TestPermissions(object):
 
     @pytest.mark.asyncio
     async def test_require_channel_invalid(self, context_pm_fx, bot_fx):
-        @require_channel(message="https://www.youtube.com/watch?v=gvdf5n-zI14")
+        """verifies require_channel stops commands invoked in PM contexts"""
+
+        @require_channel
         async def potato(context: Context):
             context.reply("hi there!")
 
         await potato(context_pm_fx)
 
-        assert "https://www.youtube.com/watch?v=gvdf5n-zI14" == bot_fx.sent_messages[0]['message']
+        assert "This command must be invoked in a channel." == bot_fx.sent_messages[0]['message']
+
+    @pytest.mark.asyncio
+    async def test_require_channel_bare_channel(self, context_channel_fx: Context):
+        """
+        Verifies @require_channel behaves properly as a plain invocation behaves as expected
+            in a channel context
+        """
+
+        @require_channel
+        async def protected(context: Context):
+            """protected function"""
+            return "hot potato!"
+
+        data = await protected(context_channel_fx)
+        assert data == "hot potato!"
+
+    @pytest.mark.asyncio
+    async def test_require_channel_bare_pm(self, context_pm_fx: Context, bot_fx):
+        """
+        Verifies @require_channel behaves properly as a plain invocation behaves as expected
+            in a pm context
+        """
+
+        @require_channel
+        async def protected(context: Context):
+            """protected function"""
+            return "hot potato!"
+
+        await protected(context_pm_fx)
+        assert "This command must be invoked in a channel." == bot_fx.sent_messages[0]['message']
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("message", ["nope.", "https://www.youtube.com/watch?v=gvdf5n-zI14"])
+    async def test_require_channel_call_channel(self, context_channel_fx: Context, message: str):
+        """
+        Verifies @require_channel behaves properly as a plain invocation behaves as expected
+            in a channel context
+        """
+
+        @require_channel(message=message)
+        async def protected(context: Context):
+            """protected function"""
+            return "hot potato!"
+
+        data = await protected(context_channel_fx)
+        assert data == "hot potato!"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("message", ["nope.", "https://www.youtube.com/watch?v=gvdf5n-zI14"])
+    async def test_require_channel_call_pm(self, context_pm_fx: Context, bot_fx, message: str):
+        """
+        Verifies @require_channel behaves properly as a plain invocation behaves as expected
+            in a pm context
+        """
+
+        @require_channel(message=message)
+        async def protected(context: Context):
+            """protected function"""
+            return "hot potato!"
+
+        await protected(context_pm_fx)
+        assert message == bot_fx.sent_messages[0]['message']
 
     @pytest.mark.asyncio
     async def test_require_dm_valid(self, context_pm_fx):


### PR DESCRIPTION
This was a bit of a doozy.

As described in SPARK-53 there was a bug that required the `@require_channel` and `@require_dm` to be used as follows:
```py
@require_channel()
async def my_command(...)
```

the empty `()` being an anoying requirement. This PR fixes that.

the valid usages for the decorators has been corrected, can can be used in either of the following forms
```py
@require_channel
async def my_command(...)
```
which will use the default access denied message.

```py
@require_channel(message="Heck no.")
async def my_command(...)
```
The kwarg **must be specified**, if the kwarg is not specified it will be ignored and the function may be have unexpectidly. 

Fixes SPARK-53