### PR TITLE
SPARK-54, SPARK-55 and SPARK-56: Rule decorator improvements

### DIFF
--- a/Modules/permissions.py
+++ b/Modules/permissions.py
@@ -225,10 +225,10 @@ def require_permission(permission: Permission,
         log.debug(f"Wrapping a command with permission {permission}")
 
         @wraps(func)
-        async def guarded(context: Context):
+        async def guarded(context: Context, *args):
             if context.user.identified and context.user.hostname in _by_vhost.keys() \
                     and _by_vhost[context.user.hostname] >= permission:
-                return await func(context)
+                return await func(context, *args)
             else:
                 await context.reply(override_message if override_message
                                     else permission.denied_message)
@@ -283,7 +283,7 @@ def require_channel(func: Union[str, Callable] = None,
         """
 
         @wraps(wrapped)
-        async def guarded(context: Context) -> Any:
+        async def guarded(context: Context, *args) -> Any:
             """
             Enforces channel requirement
 
@@ -294,7 +294,7 @@ def require_channel(func: Union[str, Callable] = None,
                 Any: whatever the called function returned
             """
             if context.channel is not None:
-                return await wrapped(context)
+                return await wrapped(context, *args)
             else:
                 log.debug(f"channel was None, enforcing channel requirement...")
                 await context.reply(message)
@@ -354,7 +354,7 @@ def require_dm(func: Union[str, Callable] = None,
         """
 
         @wraps(wrapped)
-        async def guarded(context: Context) -> Any:
+        async def guarded(context: Context, *args) -> Any:
             """
             Enforces channel requirement
 
@@ -365,7 +365,7 @@ def require_dm(func: Union[str, Callable] = None,
                 Any: whatever the called function returned
             """
             if context.channel is None:
-                return await wrapped(context)
+                return await wrapped(context, *args)
             else:
                 log.debug(f"channel was None, enforcing channel requirement...")
                 await context.reply(message)

--- a/Modules/rat_command.py
+++ b/Modules/rat_command.py
@@ -229,8 +229,9 @@ def command(*aliases):
 
 _RuleTuple = NamedTuple("_RuleTuple", underlying=Callable, full_message=bool, pass_match=bool)
 
-def rule(regex: str, *, case_sensitive: bool=False, full_message: bool=False, pass_match: bool=False,
-         prefixless: bool=False):
+
+def rule(regex: str, *, case_sensitive: bool=False, full_message: bool=False,
+         pass_match: bool=False, prefixless: bool=False):
     """
     Decorator to have the underlying coroutine be called when two conditions apply:
     1. No conventional command was found for the incoming message.

--- a/Modules/rat_command.py
+++ b/Modules/rat_command.py
@@ -99,11 +99,8 @@ async def trigger(message: str, sender: str, channel: str):
         else:
             words.append(word)
 
-        # casts the command to lower case, for case insensitivity
-    words[0] = words[0].lower()
-
-    if words[0] in _registered_commands.keys():
-        cmd = _registered_commands[words[0]]
+    if words[0].lower() in _registered_commands.keys():
+        cmd = _registered_commands[words[0].lower()]
     else:
         for key, value in _rules.items():
             if key.match(words[0]) is not None:

--- a/Modules/rat_command.py
+++ b/Modules/rat_command.py
@@ -13,12 +13,12 @@ This module is built on top of the Pydle system.
 """
 
 import logging
-import re
-from typing import Callable, Dict, Pattern, NamedTuple, Optional, List, Tuple
+from typing import Callable, List, Tuple
 
 from pydle import BasicClient
 
 from Modules.context import Context
+from Modules.rules import get_rule, clear_rules
 from Modules.user import User
 from config import config
 
@@ -48,8 +48,6 @@ class NameCollisionException(CommandException):
 
 
 _registered_commands = {}
-_rules: Dict[Pattern, "_RuleTuple"] = {}
-_prefixless_rules: Dict[Pattern, "_RuleTuple"] = {}
 
 # character/s that must prefix a message for it to be parsed as a command.
 prefix = config['commands']['prefix']
@@ -82,14 +80,14 @@ async def trigger(message: str, sender: str, channel: str):
             log.debug(f"Regular command {words[0]} invoked.")
         else:
             # Might be a regular rule
-            command_fun, extra_args = _get_rule(words, words_eol, _rules)
+            command_fun, extra_args = get_rule(words, words_eol, prefixless=False)
             if command_fun:
                 log.debug(f"Rule {getattr(command_fun, '__name__', '')} matching {words[0]} found.")
             else:
                 log.warning(f"Could not find command or rule for {prefix}{words[0]}.")
     else:
         # Might still be a prefixless rule
-        command_fun, extra_args = _get_rule(words, words_eol, _prefixless_rules)
+        command_fun, extra_args = get_rule(words, words_eol, prefixless=True)
         if command_fun:
             log.debug(f"Prefixless rule {getattr(command_fun, '__name__', '')} matching {words[0]} "
                       f"found.")
@@ -100,36 +98,6 @@ async def trigger(message: str, sender: str, channel: str):
         return await command_fun(context, *extra_args)
     else:
         log.debug(f"Ignoring message '{message}'. Not a command or rule.")
-
-
-def _get_rule(words: List[str], words_eol: List[str],
-              from_dict: Dict[Pattern, "_RuleTuple"]) -> Tuple[Optional[Callable], tuple]:
-    """
-    Attempt to find a rule in the given dict of patterns and rules.
-
-    Args:
-        words: Words of the message.
-        words_eol: Words of the message, but each including everything to the end of it.
-        from_dict: Dict mapping patterns to their rules.
-
-    Returns:
-        (Callable or None, tuple):
-            2-tuple of the command function and the extra args that it should
-            be called with.
-    """
-    for pattern, (fun, full_message, pass_match) in from_dict.items():
-        if full_message:
-            match = pattern.match(words_eol[0])
-        else:
-            match = pattern.match(words[0])
-
-        if match is not None:
-            if pass_match:
-                return fun, (match,)
-            else:
-                return fun, ()
-    else:
-        return None, ()
 
 
 def _split_message(string: str) -> Tuple[List[str], List[str]]:
@@ -200,9 +168,9 @@ def _flush() -> None:
     Flushes registered commands
     Probably useless outside testing...
     """
-    global _registered_commands, _rules  # again this feels ugly but they are module-level now...
+    global _registered_commands  # again this feels ugly but they are module-level now...
     _registered_commands = {}
-    _rules = {}
+    clear_rules()
 
 
 def command(*aliases):
@@ -231,49 +199,3 @@ def command(*aliases):
 
         return func
     return real_decorator
-
-
-_RuleTuple = NamedTuple("_RuleTuple", underlying=Callable, full_message=bool, pass_match=bool)
-
-
-def rule(regex: str, *, case_sensitive: bool=False, full_message: bool=False,
-         pass_match: bool=False, prefixless: bool=False):
-    """
-    Decorator to have the underlying coroutine be called when two conditions apply:
-    1. No conventional command was found for the incoming message.
-    2. The command matches the here provided regular expression.
-
-    Arguments:
-        regex (str):
-            Regular expression to match the command.
-        case_sensitive (bool):
-            Whether to match case-sensitively (using the re.IGNORECASE flag).
-        full_message (bool):
-            If this is True, will try to match against the full message. Otherwise,
-            only the word will be matched against.
-        pass_match (bool):
-            If this is True, the match object will be passed as an argument toward the command
-            function.
-        prefixless (bool):
-            If this is True, the rule can match whether or not the prefix is present. Otherwise, it
-            acts similarly to a command, only being considered if the message starts with our
-            prefix. The prefix itself should not be part of the regex for non-prefixless rules.
-
-    Please note that *regex* can match anywhere within the string, it need not match the entire
-    string. If you wish to change this behaviour, use '^' and '$' in your regex.
-    """
-    def decorator(coro: Callable):
-        if case_sensitive:
-            pattern = re.compile(regex)
-        else:
-            pattern = re.compile(regex, re.IGNORECASE)
-
-        if prefixless:
-            _prefixless_rules[pattern] = _RuleTuple(coro, full_message, pass_match)
-        else:
-            _rules[pattern] = _RuleTuple(coro, full_message, pass_match)
-
-        log.info(f"New rule matching '{regex}' case-{'' if case_sensitive else 'in'}sensitively was"
-                 f" created.")
-        return coro
-    return decorator

--- a/Modules/rat_command.py
+++ b/Modules/rat_command.py
@@ -98,6 +98,8 @@ async def trigger(message: str, sender: str, channel: str):
         user = await User.from_whois(bot, sender)
         context = Context(bot, user, channel, words, words_eol)
         return await command_fun(context, *extra_args)
+    else:
+        log.debug(f"Ignoring message '{message}'. Not a command or rule.")
 
 
 def _get_rule(words: List[str], words_eol: List[str],

--- a/Modules/rat_command.py
+++ b/Modules/rat_command.py
@@ -144,6 +144,10 @@ def _split_message(string: str) -> Tuple[List[str], List[str]]:
             A 2-tuple of (words, words_eol), where words is a list of the words of *string*,
             seperated by whitespace, and words_eol is a list of the same length, with each element
             including the word and everything up to the end of *string*
+
+    Example:
+        >>> _split_message("pink fluffy unicorns")
+        (['pink', 'fluffy', 'unicorns'], ['pink fluffy unicorns', 'fluffy unicorns', 'unicorns'])
     """
     words = []
     words_eol = []

--- a/Modules/rat_command.py
+++ b/Modules/rat_command.py
@@ -85,9 +85,14 @@ async def trigger(message: str, sender: str, channel: str):
             command_fun, extra_args = _get_rule(words, words_eol, _rules)
             if command_fun:
                 log.debug(f"Rule {getattr(command_fun, '__name__', '')} matching {words[0]} found.")
+            else:
+                log.warning(f"Could not find command or rule for {prefix}{words[0]}.")
     else:
         # Might still be a prefixless rule
         command_fun, extra_args = _get_rule(words, words_eol, _prefixless_rules)
+        if command_fun:
+            log.debug(f"Prefixless rule {getattr(command_fun, '__name__', '')} matching {words[0]} "
+                      f"found.")
 
     if command_fun:
         user = await User.from_whois(bot, sender)

--- a/Modules/rat_command.py
+++ b/Modules/rat_command.py
@@ -99,8 +99,8 @@ async def trigger(message: str, sender: str, channel: str):
         else:
             words.append(word)
 
-    if words[0].lower() in _registered_commands.keys():
-        cmd = _registered_commands[words[0].lower()]
+    if words[0].casefold() in _registered_commands.keys():
+        cmd = _registered_commands[words[0].casefold()]
     else:
         for key, value in _rules.items():
             if key.match(words[0]) is not None:
@@ -126,7 +126,7 @@ def _register(func, names: list or str) -> bool:
         names = [names]  # idiot proofing
 
     # transform commands to lowercase
-    names = [name.lower() for name in names]
+    names = [name.casefold() for name in names]
 
     if func is None or not callable(func):
         # command not callable

--- a/Modules/rat_command.py
+++ b/Modules/rat_command.py
@@ -40,13 +40,6 @@ class InvalidCommandException(CommandException):
     pass
 
 
-class CommandNotFoundException(CommandException):
-    """
-    Command not found.
-    """
-    pass
-
-
 class NameCollisionException(CommandException):
     """
     Someone attempted to register a command already registered.

--- a/Modules/rat_command.py
+++ b/Modules/rat_command.py
@@ -180,7 +180,7 @@ def command(*aliases):
     return real_decorator
 
 
-def rule(regex: str):
+def rule(regex: str, case_sensitive: bool=False):
     """
     Decorator to have the underlying coroutine be called when two conditions apply:
     1. No conventional command was found for the incoming message.
@@ -188,9 +188,16 @@ def rule(regex: str):
 
     Arguments:
         regex (str): Regular expression to match the command.
+        case_sensitive (bool): Whether to match case-sensitively (using the re.IGNORECASE flag).
     """
     def decorator(coro: Callable):
-        _rules[re.compile(regex, re.IGNORECASE)] = coro
-        log.info(f"New rule matching '{regex}' was created.")
+        if case_sensitive:
+            pattern = re.compile(regex)
+        else:
+            pattern = re.compile(regex, re.IGNORECASE)
+
+        _rules[pattern] = coro
+        log.info(f"New rule matching '{regex}' case-{'' if case_sensitive else 'in'}sensitively was"
+                 f" created.")
         return coro
     return decorator

--- a/Modules/rat_command.py
+++ b/Modules/rat_command.py
@@ -99,20 +99,18 @@ async def trigger(message: str, sender: str, channel: str):
         else:
             words.append(word)
 
-    if words[0].casefold() in _registered_commands.keys():
-        cmd = _registered_commands[words[0].casefold()]
-    else:
-        for key, value in _rules.items():
-            if key.match(words[0]) is not None:
-                cmd = value
-                break
-        else:
-            raise CommandNotFoundException(f"Unable to find command {words[0]}")
-
     user = await User.from_whois(bot, sender)
     context = Context(bot, user, channel, words, words_eol)
 
-    return await cmd(context)
+    if words[0].casefold() in _registered_commands.keys():
+        return await _registered_commands[words[0].casefold()](context)
+    else:
+        for key, value in _rules.items():
+            match = key.match(words[0])
+            if match is not None:
+                return await value(context, match)
+        else:
+            raise CommandNotFoundException(f"Unable to find command {words[0]}")
 
 
 def _register(func, names: list or str) -> bool:

--- a/Modules/rules.py
+++ b/Modules/rules.py
@@ -130,6 +130,5 @@ def get_rule(words: List[str], words_eol: List[str],
 
 
 def clear_rules():
-    global _prefixless_rules, _rules
-    _prefixless_rules = []
-    _rules = []
+    _prefixless_rules.clear()
+    _rules.clear()

--- a/Modules/rules.py
+++ b/Modules/rules.py
@@ -1,0 +1,89 @@
+import logging
+import re
+from typing import Callable, NamedTuple, Pattern, List, Tuple, Optional
+
+log = logging.getLogger(__name__)
+
+_rules: List["_RuleTuple"] = []
+_prefixless_rules: List["_RuleTuple"] = []
+
+_RuleTuple = NamedTuple("_RuleTuple", pattern=Pattern, underlying=Callable, full_message=bool, pass_match=bool)
+
+
+def rule(regex: str, *, case_sensitive: bool=False, full_message: bool=False,
+         pass_match: bool=False, prefixless: bool=False):
+    """
+    Decorator to have the underlying coroutine be called when two conditions apply:
+    1. No conventional command was found for the incoming message.
+    2. The command matches the here provided regular expression.
+
+    Arguments:
+        regex (str):
+            Regular expression to match the command.
+        case_sensitive (bool):
+            Whether to match case-sensitively (using the re.IGNORECASE flag).
+        full_message (bool):
+            If this is True, will try to match against the full message. Otherwise,
+            only the word will be matched against.
+        pass_match (bool):
+            If this is True, the match object will be passed as an argument toward the command
+            function.
+        prefixless (bool):
+            If this is True, the rule can match whether or not the prefix is present. Otherwise, it
+            acts similarly to a command, only being considered if the message starts with our
+            prefix. The prefix itself should not be part of the regex for non-prefixless rules.
+
+    Please note that *regex* can match anywhere within the string, it need not match the entire
+    string. If you wish to change this behaviour, use '^' and '$' in your regex.
+    """
+    def decorator(coro: Callable):
+        if case_sensitive:
+            pattern = re.compile(regex)
+        else:
+            pattern = re.compile(regex, re.IGNORECASE)
+
+        if prefixless:
+            _prefixless_rules.append(_RuleTuple(pattern, coro, full_message, pass_match))
+        else:
+            _rules.append(_RuleTuple(pattern, coro, full_message, pass_match))
+
+        log.info(f"New rule matching '{regex}' case-{'' if case_sensitive else 'in'}sensitively was"
+                 f" created.")
+        return coro
+    return decorator
+
+
+def get_rule(words: List[str], words_eol: List[str],
+             prefixless: bool) -> Tuple[Optional[Callable], tuple]:
+    """
+    Attempt to find a rule in the given dict of patterns and rules.
+
+    Args:
+        words: Words of the message.
+        words_eol: Words of the message, but each including everything to the end of it.
+        prefixless: Whether or not we're looking for prefixless rules.
+
+    Returns:
+        (Callable or None, tuple):
+            2-tuple of the command function and the extra args that it should
+            be called with.
+    """
+    for (pattern, fun, full_message, pass_match) in (_prefixless_rules if prefixless else _rules):
+        if full_message:
+            match = pattern.match(words_eol[0])
+        else:
+            match = pattern.match(words[0])
+
+        if match is not None:
+            if pass_match:
+                return fun, (match,)
+            else:
+                return fun, ()
+    else:
+        return None, ()
+
+
+def clear_rules():
+    global _prefixless_rules, _rules
+    _prefixless_rules = []
+    _rules = []

--- a/Modules/rules.py
+++ b/Modules/rules.py
@@ -17,8 +17,6 @@ class Rule(NamedTuple):
     def __eq__(self, other):
         if isinstance(other, Rule):
             return self.pattern == other.pattern and self.full_message == other.full_message
-        elif isinstance(other, tuple):
-            return super() == other
         else:
             return NotImplemented
 

--- a/Modules/rules.py
+++ b/Modules/rules.py
@@ -112,17 +112,17 @@ def get_rule(words: List[str], words_eol: List[str],
             2-tuple of the command function and the extra args that it should
             be called with.
     """
-    for (pattern, fun, full_message, pass_match) in (_prefixless_rules if prefixless else _rules):
-        if full_message:
-            match = pattern.match(words_eol[0])
+    for rule in (_prefixless_rules if prefixless else _rules):
+        if rule.full_message:
+            match = rule.pattern.match(words_eol[0])
         else:
-            match = pattern.match(words[0])
+            match = rule.pattern.match(words[0])
 
         if match is not None:
-            if pass_match:
-                return fun, (match,)
+            if rule.pass_match:
+                return rule.underlying, (match,)
             else:
-                return fun, ()
+                return rule.underlying, ()
     else:
         return None, ()
 

--- a/main.py
+++ b/main.py
@@ -87,12 +87,6 @@ class MechaClient(Client):
             # self-stimulated positive feedback loop.
             log.debug(f"Ignored {message} (anti-loop)")
             return None
-
-        if not message.startswith(rat_command.prefix):
-            # prevent bot from processing commands without the set prefix
-            log.debug(f"Ignored {message} (not a command)")
-            return None
-
         else:  # await command execution
             # sanitize input string headed to command executor
             sanitized_message = sanitize(message)

--- a/main.py
+++ b/main.py
@@ -24,7 +24,7 @@ from Modules import graceful_errors
 from Modules import rat_command
 from Modules.context import Context
 from Modules.permissions import require_permission, RAT
-from Modules.rat_command import command, CommandNotFoundException
+from Modules.rat_command import command
 from config import config
 from utils.ratlib import sanitize
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,6 +45,7 @@ from Modules.context import Context
 from Modules.epic import Epic
 from Modules.user import User
 from Modules.mark_for_deletion import MarkForDeletion
+from tests.mocks import CallableMock, AsyncCallableMock
 
 
 @pytest.fixture(params=[("pcClient", Platforms.PC, "firestone", 24),
@@ -238,7 +239,6 @@ def reset_rat_cache_fx(rat_cache_fx: RatCache):
     # and clean up after ourselves
     rat_cache_fx.flush()
 
-
 @pytest.fixture
 def permission_fx(monkeypatch) -> Permission:
     """
@@ -254,3 +254,23 @@ def permission_fx(monkeypatch) -> Permission:
     monkeypatch.setattr("Modules.permissions._by_vhost", {})
     permission = Permission(0, {"testing.fuelrats.com", "cheddar.fuelrats.com"})
     return permission
+
+@pytest.fixture
+def callable_fx():
+    """
+    Fixture providing a callable object whose return value can be set and which can be checked for
+    having been called.
+
+    See :class:`CallableMock`.
+    """
+    return CallableMock()
+
+
+@pytest.fixture
+def async_callable_fx():
+    """
+    Like :func:`callable_fx`, but can be treated as a coroutine function.
+
+    See :class:`AsyncCallableMock`.
+    """
+    return AsyncCallableMock()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,7 +45,7 @@ from Modules.context import Context
 from Modules.epic import Epic
 from Modules.user import User
 from Modules.mark_for_deletion import MarkForDeletion
-from tests.mocks import CallableMock, AsyncCallableMock
+from tests.mock_callables import CallableMock, AsyncCallableMock
 
 
 @pytest.fixture(params=[("pcClient", Platforms.PC, "firestone", 24),

--- a/tests/mock_callables.py
+++ b/tests/mock_callables.py
@@ -8,8 +8,7 @@ Licensed under the BSD 3-Clause License.
 
 See LICENSE.
 """
-from typing import List, NamedTuple, Dict, Any
-
+from typing import List, NamedTuple, Dict, Any, Tuple
 
 _Call = NamedTuple("_Call", args=tuple, kwargs=Dict[str, Any])
 
@@ -73,7 +72,12 @@ class CallableMock(object):
 
     was_called_once: bool = property(lambda self: len(self._calls) == 1)
     """
-    Was this instance called exactly one?
+    Was this instance called exactly once?
+    """
+
+    calls: Tuple[_Call, ...] = property(lambda self: tuple(self._calls))
+    """
+    A read-only view of the calls that were made to this object.
     """
 
     def was_called_with(self, *args, **kwargs) -> bool:

--- a/tests/mock_callables.py
+++ b/tests/mock_callables.py
@@ -1,5 +1,5 @@
 """
-mocks.py - Small, miscellaneous mock classes.
+mocks.py - Mock callables. Objects that can be called and later inquired as to how they were called.
 
 Copyright (c) 2018 The Fuel Rats Mischief,
 All rights reserved.

--- a/tests/mock_callables.py
+++ b/tests/mock_callables.py
@@ -87,6 +87,12 @@ class CallableMock(object):
         """
         return _Call(args, kwargs) in self._calls
 
+    def reset(self):
+        """
+        Reset all saved calls to this mock.
+        """
+        self._calls.clear()
+
 
 class AsyncCallableMock(CallableMock):
     """

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -1,0 +1,93 @@
+"""
+mocks.py - Small, miscellaneous mock classes.
+
+Copyright (c) 2018 The Fuel Rats Mischief,
+All rights reserved.
+
+Licensed under the BSD 3-Clause License.
+
+See LICENSE.
+"""
+from typing import List, NamedTuple, Dict, Any
+
+
+_Call = NamedTuple("_Call", args=tuple, kwargs=Dict[str, Any])
+
+
+class InstanceOf(object):
+    """
+    Simple wrapper around a class. To be used in conjunction with :class:`CallableMock` instances.
+    Instances of :class:`InstanceOf` compare equal with instances of their wrapped type.
+
+    Examples:
+        >>> InstanceOf(str) == "hello"
+        True
+        >>> InstanceOf(dict) == 7
+        False
+    """
+    __slots__ = ("klass",)
+
+    def __init__(self, klass: type):
+        self.klass = klass
+
+    def __eq__(self, other):
+        if isinstance(other, self.klass):
+            return True
+        elif isinstance(other, InstanceOf):
+            return self.klass is other.klass
+        else:
+            return NotImplemented
+
+
+class CallableMock(object):
+    """
+    Similar to unittest's MagicMock, this class is callable. It allows the user to set a return
+    value and to inquire after the fact what it has been called with.
+
+    Examples:
+        >>> fun = CallableMock()
+        >>> fun(1, 2, 3, her="lo")
+        >>> fun.was_called
+        True
+        >>> fun.was_called_once
+        True
+        >>> fun.was_called_with(1, 2, 3, her="lo")
+        True
+        >>> fun.was_called_with(3, 2, "herlo")
+        False
+        >>> fun.was_called_with(InstanceOf(int), 2, 3, her=InstanceOf(str))
+        True
+    """
+    def __init__(self):
+        self.return_value = None
+        self._calls: List[_Call] = []
+
+    def __call__(self, *args, **kwargs):
+        self._calls.append(_Call(args, kwargs))
+        return self.return_value
+
+    was_called: bool = property(lambda self: len(self._calls) > 0)
+    """
+    Was this instance ever called?
+    """
+
+    was_called_once: bool = property(lambda self: len(self._calls) == 1)
+    """
+    Was this instance called exactly one?
+    """
+
+    def was_called_with(self, *args, **kwargs) -> bool:
+        """
+        Was this instance called with the given arguments?
+        Can take :class:`InstanceOf` objects to check for types.
+        """
+        return _Call(args, kwargs) in self._calls
+
+
+class AsyncCallableMock(CallableMock):
+    """
+    This is like :class:`CallableMock`, however calling it returns an awaitable coroutine rather
+    than the set return value directly.
+    """
+    async def __call__(self, *args, **kwargs):
+        return super().__call__(*args, **kwargs)

--- a/tests/test_rat_command.py
+++ b/tests/test_rat_command.py
@@ -143,6 +143,32 @@ class TestRatCommand(object):
         assert async_callable_fx.calls[0].args[1].groups() == ("lo",)
 
     @pytest.mark.asyncio
+    async def test_prefixless_rule_called(self, async_callable_fx: AsyncCallableMock):
+        """
+        Verifies that prefixless rules are considered when the prefix is not present.
+        """
+        Commands.rule("da_da(_da)?", prefixless=True)(async_callable_fx)
+        await Commands.trigger("da_da", "unit_test", "#unit_test")
+
+        assert async_callable_fx.was_called_once
+        assert async_callable_fx.was_called_with(InstanceOf(Context))
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("regex,message", [
+        ("woof", "!woof woof"),
+        ("!woof", "!woof woof")
+    ])
+    async def test_prefixless_rule_not_called(self, regex: str, message: str,
+                                              async_callable_fx: AsyncCallableMock):
+        """
+        Verifies that prefixless rules are not considered if the prefix is present.
+        """
+        Commands.rule(regex, prefixless=True)(async_callable_fx)
+        await Commands.trigger(message, "unit_test", "#unit_test")
+
+        assert not async_callable_fx.was_called
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize("alias", ['potato', 'cannon', 'Fodder', "fireball"])
     async def test_command_decorator_single(self, alias: str):
         """

--- a/tests/test_rat_command.py
+++ b/tests/test_rat_command.py
@@ -37,11 +37,8 @@ class TestRatCommand(object):
         """
         Ensures that nothing happens and `trigger` exits quietly when no command can be found.
         """
-        try:
-            await Commands.trigger(message="!nope", sender="unit_test",
-                                   channel="foo")
-        except BaseException as e:
-            pytest.fail("trigger raised " + type(e).__name__)
+        await Commands.trigger(message="!nope", sender="unit_test",
+                               channel="foo")
 
     @pytest.mark.parametrize("alias", ['potato', 'cannon', 'Fodder', 'fireball'])
     def test_double_command_registration(self, alias):

--- a/tests/test_rat_command.py
+++ b/tests/test_rat_command.py
@@ -15,6 +15,7 @@ This module is built on top of the Pydle system.
 """
 
 import asyncio
+from typing import Match
 from unittest import mock
 
 import pydle
@@ -119,6 +120,25 @@ class TestRatCommand(object):
         with pytest.raises(CommandNotFoundException):
             await Commands.trigger("!banan", "unit_test", "theOneWithTheHills")
         assert not underlying.called
+
+    @pytest.mark.asyncio
+    async def test_rule_passes_match(self):
+        """
+        Verifies that the rules get passed the match object correctly.
+        """
+        called = False
+
+        @Commands.rule("her(lo)")
+        async def my_rule(context: Context, match: Match):
+            assert isinstance(context, Context)
+            assert isinstance(match, Match)
+            assert match.groups() == ("lo",)
+
+            nonlocal called
+            called = True
+
+        await Commands.trigger("!herlo", "unit_test", "#unit_test")
+        assert called
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("alias", ['potato', 'cannon', 'Fodder', "fireball"])

--- a/tests/test_rat_command.py
+++ b/tests/test_rat_command.py
@@ -161,7 +161,7 @@ class TestRatCommand(object):
         """
         Commands._flush()
         ftrigger = f"!{name} {trigger_message}"
-        words = [name.lower()] + trigger_message.split(" ")
+        words = [name] + trigger_message.split(" ")
 
         @Commands.command(name)
         async def the_command(context: Context):

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -1,0 +1,87 @@
+from typing import Match
+
+import pytest
+
+from Modules.context import Context
+from Modules.rat_command import trigger
+from Modules.rules import rule, clear_rules
+from tests.mock_callables import AsyncCallableMock, InstanceOf
+
+
+@pytest.fixture(autouse=True)
+def clear_rules_fx():
+    clear_rules()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("regex,case_sensitive,full_message,message", [
+    ("^banan(a|e)$", True, False, "!banana"),
+    ("^banan(a|e)$", True, False, "!banane"),
+    ("^dabadoop$", False, False, "!DABADOOP"),
+    ("na na", False, True, "!na na")
+])
+async def test_rule_matching(async_callable_fx: AsyncCallableMock, regex: str,
+                             case_sensitive: bool, full_message: bool, message: str):
+    """Verifies that the rule decorator works as expected."""
+    rule(regex, case_sensitive=case_sensitive,
+         full_message=full_message)(async_callable_fx)
+
+    await trigger(message, "unit_test", "#mordor")
+    assert async_callable_fx.was_called_once
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("regex,case_sensitive,full_message,message", [
+    ("^banan(a|e)$", True, False, "!banan"),
+    ("^banan(a|e)$", True, False, "!bananae"),
+    ("^dabadoop$", True, False, "!DABADOOP"),
+    ("na na", False, False, "!na na")
+])
+async def test_rule_not_matching(async_callable_fx: AsyncCallableMock, regex: str,
+                                 case_sensitive: bool, full_message: bool, message: str):
+    """verifies that the rule decorator works as expected."""
+    rule(regex, case_sensitive=case_sensitive,
+         full_message=full_message)(async_callable_fx)
+    await trigger(message, "unit_test", "theOneWithTheHills")
+    assert not async_callable_fx.was_called
+
+
+@pytest.mark.asyncio
+async def test_rule_passes_match(async_callable_fx: AsyncCallableMock):
+    """
+    Verifies that the rules get passed the match object correctly.
+    """
+    rule("her(lo)", pass_match=True)(async_callable_fx)
+    await trigger("!herlo", "unit_test", "#unit_test")
+
+    assert async_callable_fx.was_called_once
+    assert async_callable_fx.was_called_with(InstanceOf(Context), InstanceOf(Match))
+    assert async_callable_fx.calls[0].args[1].groups() == ("lo",)
+
+
+@pytest.mark.asyncio
+async def test_prefixless_rule_called(async_callable_fx: AsyncCallableMock):
+    """
+    Verifies that prefixless rules are considered when the prefix is not present.
+    """
+    rule("da_da(_da)?", prefixless=True)(async_callable_fx)
+    await trigger("da_da", "unit_test", "#unit_test")
+
+    assert async_callable_fx.was_called_once
+    assert async_callable_fx.was_called_with(InstanceOf(Context))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("regex,message", [
+    ("woof", "!woof woof"),
+    ("!woof", "!woof woof")
+])
+async def test_prefixless_rule_not_called(regex: str, message: str,
+                                          async_callable_fx: AsyncCallableMock):
+    """
+    Verifies that prefixless rules are not considered if the prefix is present.
+    """
+    rule(regex, prefixless=True)(async_callable_fx)
+    await trigger(message, "unit_test", "#unit_test")
+
+    assert not async_callable_fx.was_called

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -85,3 +85,20 @@ async def test_prefixless_rule_not_called(regex: str, message: str,
     await trigger(message, "unit_test", "#unit_test")
 
     assert not async_callable_fx.was_called
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("regex,full_message,prefixless", [
+    ("woof", False, False),
+    ("blue moon", True, True),
+    ("herlo there", True, False)
+])
+async def test_rule_duplicate_raises(regex: str, full_message: str, prefixless: str,
+                                     async_callable_fx: AsyncCallableMock):
+    """
+    Ensures that a ValueError is raises when two rules with the same regex, full_message and
+    prefixlessness are being registered.
+    """
+    rule(regex, full_message=full_message, prefixless=prefixless)(async_callable_fx)
+    with pytest.raises(ValueError):
+        rule(regex, full_message=full_message, prefixless=prefixless)(async_callable_fx)


### PR DESCRIPTION
This PR implements SPARK-55 and the SPARK-54, which it requires. It also implements SPARK-56.

It adds a `pass_match` parameter to the rule decorator to implement SPARK-55. It also adds a parameter for toggling case-sensitivity as well as one to switch whether the regex should match the entire message (minus the prefix on non-prefixless rules, see below) or just the first word (for command-like rules).

SPARK-56's prefixless rules are also implemented. This did, however, need some doing in the command triggering logic: `MechaClient.on_message` now only checks that the message does not come from Mecha itself. `rat_command.trigger` tries to find a command, a regular old rule or a prefixless rule, in that order. If it can't find anything, it returns, possibly logging a warning. These changes also remove the need for `CommandNotFoundException`.

To facilitate simpler tests, this PR also adds callable mocks somewhat similar to those from unittest. These can be inquired as to if and how they were called. There is also an async version which can be treated as a coroutine function.