### PR TITLE
Implement a Singleton

### DIFF
--- a/tests/test_ratlib.py
+++ b/tests/test_ratlib.py
@@ -1,6 +1,7 @@
 import pytest
 
 import utils.ratlib
+from utils.ratlib import Singleton
 
 pytestmark = pytest.mark.ratlib
 
@@ -45,3 +46,40 @@ def test_sanitize(input_message, expected_message):
     Verifies sanitize routine is properly removing string elements.
     """
     assert utils.ratlib.sanitize(input_message) == expected_message
+
+
+def test_singleton_direct_inheritance():
+    """
+    Verifies the Singleton class behaves as expected for classes directly inheriting
+    """
+
+    class Potato(Singleton):
+        pass
+
+    # noinspection PyUnresolvedReferences
+    assert Potato._instance is None
+    foo = Potato()
+    bar = Potato()
+    assert foo is bar
+    # noinspection PyUnresolvedReferences
+    assert Potato._instance is foo
+
+
+def test_singleton_indirect_inheritance():
+    """
+    Verifies the Singleton class behaves as expected for classes ultimately derived from Singleton
+    """
+
+    class Potato(Singleton):
+        pass
+
+    class Snafu(Potato):
+        pass
+
+    # noinspection PyUnresolvedReferences
+    assert Snafu._instance is None
+    foo = Snafu()
+    bar = Snafu()
+    assert foo is bar
+    # noinspection PyUnresolvedReferences
+    assert Snafu._instance is foo

--- a/utils/ratlib.py
+++ b/utils/ratlib.py
@@ -11,9 +11,9 @@ See LICENSE.md
 This module is built on top of the Pydle system.
 
 """
-from enum import Enum
 import re
-from uuid import UUID, uuid4
+from enum import Enum
+from uuid import UUID
 
 MIRC_CONTROL_CODES = ["\x0F", "\x16", "\x1D", "\x1F", "\x02",
                       "\x03([1-9][0-6]?)?,?([1-9][0-6]?)?"]
@@ -39,6 +39,37 @@ class Status(Enum):
     """The rescue is currently closed"""
     INACTIVE = 2
     """The rescue is open, but is marked inactive"""
+
+
+class Singleton(object):
+    """
+    Provides a singleton base class.
+
+    Any class derived from this base will be a singleton.
+
+    Examples:
+        >>> class Potato(Singleton):
+        ...     pass
+        >>> foo = Potato()
+        >>> bar = Potato()
+        >>> foo is bar
+        true
+    """
+
+    def __new__(cls, *args, **kwargs):
+        # checks if this class already has an instance.
+        if cls._instance is None:
+            # class does not already have an instance, lets make one!
+            cls._instance = super().__new__(cls, *args, **kwargs)
+        # return the instance
+        return cls._instance
+
+    def __init_subclass__(cls, **kwargs):
+
+        # implements ._instance in all children
+        cls._instance = None
+        # and ensure the super gets called
+        super().__init_subclass__(**kwargs)
 
 
 def sanitize(message: str) -> str:

--- a/utils/ratlib.py
+++ b/utils/ratlib.py
@@ -53,7 +53,7 @@ class Singleton(object):
         >>> foo = Potato()
         >>> bar = Potato()
         >>> foo is bar
-        true
+        True
     """
 
     def __new__(cls, *args, **kwargs):


### PR DESCRIPTION
This Pr implements a Singleton base class that is not a metaclass.

Being a base class, it has the benefit that classes inheriting `Singleton` can use other metaclasses, such as `abc.ABCMeta` or `typing.Generic`.

The `Singleton` class will add the attribute `cls._instance` to all child classes,
this class attribute is where Singleton stores the single instance of the child class when it is first instantiated.
 