### PR TITLE
Reimplement `Status` to use a Flag Enum

### DIFF
--- a/Modules/rat_rescue.py
+++ b/Modules/rat_rescue.py
@@ -20,9 +20,9 @@ from uuid import UUID
 
 from Modules.epic import Epic
 from Modules.mark_for_deletion import MarkForDeletion
+from Modules.rat import Rat
 from Modules.rat_cache import RatCache
 from Modules.rat_quotation import Quotation
-from Modules.rat import Rat
 from utils.ratlib import Platforms, Status
 
 log = logging.getLogger(f"mecha.{__name__}")
@@ -50,7 +50,7 @@ class Rescue(object):
                  mark_for_deletion: MarkForDeletion = MarkForDeletion(),
                  lang_id: str = "EN",
                  rats: List[Rat] = None,
-                 status: Status = Status.OPEN,
+                 status: Status = Status.OPEN | Status.ACTIVE,
                  code_red=False):
         """
         creates a unique rescue

--- a/Modules/rat_rescue.py
+++ b/Modules/rat_rescue.py
@@ -15,7 +15,7 @@ from contextlib import contextmanager
 from datetime import datetime
 from functools import reduce
 from operator import xor
-from typing import Union, Optional, List
+from typing import Union, Optional, List, TYPE_CHECKING
 from uuid import UUID
 
 from Modules.epic import Epic
@@ -24,6 +24,9 @@ from Modules.rat import Rat
 from Modules.rat_cache import RatCache
 from Modules.rat_quotation import Quotation
 from utils.ratlib import Platforms, Status
+
+if TYPE_CHECKING:
+    from Modules.rat_board import RatBoard
 
 log = logging.getLogger(f"mecha.{__name__}")
 
@@ -445,7 +448,7 @@ class Rescue(object):
         Returns:
             bool: Active state
         """
-        return False if self.status == Status.INACTIVE else True
+        return Status.ACTIVE in self.status
 
     @active.setter
     def active(self, value: bool) -> None:
@@ -460,9 +463,15 @@ class Rescue(object):
         """
         if isinstance(value, bool):
             if value:
-                self.status = Status.OPEN
+                # we want to mark the case as active
+                if not self.active:
+                    # the case is not currently active
+                    self.status ^= Status.ACTIVE
             else:
-                self.status = Status.INACTIVE
+                # we want to make the case inactive
+                if self.active:
+                    # and it is currently active
+                    self.status ^= Status.ACTIVE
         else:
             raise ValueError(f"expected bool, got type {type(value)}")
 

--- a/tests/test_rescue.py
+++ b/tests/test_rescue.py
@@ -10,11 +10,12 @@ See LICENSE.md
 
 This module is built on top of the Pydle system.
 """
-import pytest
 from copy import deepcopy
 from datetime import datetime
 from uuid import uuid4, UUID
-from Modules.epic import Epic
+
+import pytest
+
 from Modules.mark_for_deletion import MarkForDeletion
 from Modules.rat import Rat
 from Modules.rat_rescue import Rescue
@@ -102,7 +103,7 @@ def test_updated_at_raises_typeerror(rescue_sop_fx):
     Verify Rescue.updated_at raises TypeError if given incorrect value,
     or is set to a date in the past.
     """
-    rescue_sop_fx._createdAt = datetime(1991, 1, 1, 1, 1, 1,)
+    rescue_sop_fx._createdAt = datetime(1991, 1, 1, 1, 1, 1, )
 
     # Set to a string time
     with pytest.raises(TypeError):
@@ -555,7 +556,7 @@ def test_mark_delete_invalid(rescue_sop_fx: Rescue):
 
         with pytest.raises(ValueError):
             rescue_sop_fx.mark_delete("unit_test", "")
-            
+
 
 def test_mark_for_deletion_unset(rescue_sop_fx: Rescue):
     """
@@ -575,7 +576,7 @@ def test_rescue_status_default(rescue_sop_fx):
     Verifies rescue status defaults to Status.OPEN
     """
     # Default
-    assert rescue_sop_fx.status == Status.OPEN
+    assert rescue_sop_fx.status is Status.ACTIVE | Status.OPEN
 
     # Test Getter
     assert rescue_sop_fx.open
@@ -608,15 +609,6 @@ def test_rescue_open_type_error(rescue_sop_fx):
         rescue_sop_fx.open = 'Yes'
 
 
-@pytest.mark.parametrize("expected_status", [Status.OPEN, Status.CLOSED, Status.INACTIVE])
-def test_rescue_status_enum(rescue_sop_fx, expected_status):
-    """
-    Verifies all rescue status returns properly.
-    """
-    rescue_sop_fx.status = expected_status
-    assert rescue_sop_fx.status == expected_status
-
-
 def test_rescue_status_type_error(rescue_sop_fx):
     """
     Verifies a TypeError is raised if an incorrect status value is cast.
@@ -633,20 +625,13 @@ def test_rescue_active_setter(rescue_sop_fx):
     # Default state
     assert rescue_sop_fx.active
 
-    # Set Inactive directly
+    # Set Inactive 
     rescue_sop_fx.active = False
     assert not rescue_sop_fx.active
 
-    # Set Active directly
+    # Set Active 
     rescue_sop_fx.active = True
     assert rescue_sop_fx
-
-    # Set Active by status update
-    rescue_sop_fx.status = Status.OPEN
-    assert rescue_sop_fx.active
-
-    # Set Inactive by status update
-    rescue_sop_fx.status = Status.INACTIVE
 
     with pytest.raises(ValueError):
         rescue_sop_fx.active = 'Yes'

--- a/utils/ratlib.py
+++ b/utils/ratlib.py
@@ -12,7 +12,7 @@ This module is built on top of the Pydle system.
 
 """
 import re
-from enum import Enum
+from enum import Enum, Flag, auto
 from uuid import UUID
 
 MIRC_CONTROL_CODES = ["\x0F", "\x16", "\x1D", "\x1F", "\x02",
@@ -31,14 +31,11 @@ class Platforms(Enum):
     """No platform"""
 
 
-class Status(Enum):
+class Status(Flag):
     """Rescue status enum"""
-    OPEN = 0
-    """The rescue is currently open"""
-    CLOSED = 1
-    """The rescue is currently closed"""
-    INACTIVE = 2
-    """The rescue is open, but is marked inactive"""
+    CLOSED = 0
+    OPEN = auto()
+    ACTIVE = auto()
 
 
 class Singleton(object):


### PR DESCRIPTION
This PR reimplements the `Status` enum to use Flags. this enables bitwise comparisons, is cleaner, and is more expandable.

As it stands, there are three flags implemented, though would be somewhat trivial to add more (eg a LRR flag)

- `CLOSED`, value 0, indicates a case is closed, or is otherwise not specifically flagged.
- `OPEN`, value `auto()`, flags a case as open
- `INACTIVE`, value `auto()`, flags a case as inactive

The absence of any flags is equal to being flagged as `CLOSED`.
Flags can be mixed, and are bitwise enabled.