### PR TITLE
Culled Platforms.DEFAULT, allowed usage of None in its place

### DIFF
--- a/Modules/rat.py
+++ b/Modules/rat.py
@@ -16,6 +16,7 @@ This module is built on top of the Pydle system.
 import logging
 from functools import reduce
 from operator import xor
+from typing import Optional
 from uuid import UUID
 
 from Modules.rat_cache import RatCache
@@ -35,7 +36,7 @@ class Rat(object):
     cache.
     """
 
-    def __init__(self, uuid: UUID, name: str = None, platform: Platforms = Platforms.DEFAULT):
+    def __init__(self, uuid: UUID, name: str = None, platform: Optional[Platforms] = None):
         """
         Creates a new rat
 
@@ -158,14 +159,14 @@ class Rat(object):
         return self._platform
 
     @platform.setter
-    def platform(self, value: Platforms) -> None:
+    def platform(self, value: Optional[Platforms]) -> None:
         """
         Sets the platform for a given rat
 
         Args:
             value (Platforms): new platform
         """
-        if isinstance(value, Platforms):
+        if isinstance(value, Platforms) or value is None:
             self._platform = value
         else:
             raise TypeError(f"Expected a {Platforms} object, got type {type(value)}")

--- a/Modules/rat_cache.py
+++ b/Modules/rat_cache.py
@@ -11,28 +11,23 @@ Licensed under the BSD 3-Clause License.
 
 See LICENSE.md
 """
-from typing import Dict, Optional
+from typing import Dict, Optional, TYPE_CHECKING
 from uuid import UUID
 
-from utils.ratlib import Platforms
+from utils.ratlib import Platforms, Singleton
+
+if TYPE_CHECKING:
+    from Modules.rat import Rat
 
 
-class RatCache(object):
+class RatCache(Singleton):
     """
     A cache of rat objects
     """
 
-    _instance = None  # reference to the singleton
-
-    def __new__(cls, *args, **kwargs):
-        # make this class a singleton
-        if cls._instance is None:
-            cls._instance = super().__new__(cls, *args, **kwargs)
-        return cls._instance
-
     def __init__(self, api_handler=None):
         """
-        Creates the ratcache, if it does not already exist
+        Creates the ratcache
         """
         if not hasattr(self, "_initalized"):
             self._initalized = True
@@ -97,7 +92,7 @@ class RatCache(object):
         self._cache_by_name = value
 
     async def get_rat_by_name(self, name: str,
-                              platform: Platforms = Platforms.DEFAULT,
+                              platform: Optional[Platforms] = None,
                               ) -> 'Rat' or None:
         """
         Finds a rat by name and optionally by platform
@@ -113,7 +108,8 @@ class RatCache(object):
         Returns:
             Rat - found rat
         """
-        if not isinstance(name, str) or not isinstance(platform, Platforms):
+        if not isinstance(name, str) or not isinstance(platform,
+                                                       Platforms) and platform is not None:
             raise TypeError("invalid types given.")
 
         # initialize before use
@@ -129,7 +125,7 @@ class RatCache(object):
             return found
         else:
             # we found a rat
-            return found if (found.platform == platform or platform == Platforms.DEFAULT) else None
+            return found if (found.platform == platform or platform is None) else None
 
     async def get_rat_by_uuid(self, uuid: UUID) -> Optional['Rat']:
         """

--- a/Modules/rat_rescue.py
+++ b/Modules/rat_rescue.py
@@ -15,15 +15,18 @@ from contextlib import contextmanager
 from datetime import datetime
 from functools import reduce
 from operator import xor
-from typing import Union, Optional, List
+from typing import Union, Optional, List, TYPE_CHECKING
 from uuid import UUID
 
 from Modules.epic import Epic
 from Modules.mark_for_deletion import MarkForDeletion
+from Modules.rat import Rat
 from Modules.rat_cache import RatCache
 from Modules.rat_quotation import Quotation
-from Modules.rat import Rat
 from utils.ratlib import Platforms, Status
+
+if TYPE_CHECKING:
+    from Modules.rat_board import RatBoard
 
 log = logging.getLogger(f"mecha.{__name__}")
 
@@ -83,7 +86,7 @@ class Rescue(object):
                 commander name.
             rats (list): identified (Rat)s assigned to rescue.
         """
-        self._platform: Platforms = Platforms.DEFAULT
+        self._platform: Platforms = None
         self.rat_board: 'RatBoard' = board
         self._rats = rats if rats else []
         self._createdAt: datetime = created_at if created_at else datetime.utcnow()

--- a/tests/test_rats.py
+++ b/tests/test_rats.py
@@ -12,14 +12,14 @@ class TestRatsPyTest(object):
         Platforms.XB,
         Platforms.PC,
         Platforms.PS,
-        Platforms.DEFAULT
+        None
     ])
     def test_rat_platforms(self, platform: Platforms, rat_good_fx):
         rat_good_fx.platform = platform
         assert rat_good_fx.platform == platform
 
     @pytest.mark.parametrize("garbage", [
-        None,
+        -12,
         (None,),
         [],
         {}

--- a/utils/ratlib.py
+++ b/utils/ratlib.py
@@ -27,8 +27,6 @@ class Platforms(Enum):
     PC = "PC"
     XB = "XB"
     PS = "PS"
-    DEFAULT = None
-    """No platform"""
 
 
 class Status(Enum):


### PR DESCRIPTION
`Platforms.DEFAULT` nolonger exists as requested. `None` may replace its usages