### PR TITLE
Logging Fixture change (Testing)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -182,7 +182,8 @@ def logging_fx(caplog) -> logging.Logger:
 @pytest.fixture
 def spooled_logging_fx(caplog) -> logging.Logger:
     """
-    Calls the logging engine with a spooled file for testing strings only.
+    Same as logging_fx, but under separate namespace for the logger to
+    use a temporary file.
     """
     caplog.clear()
     return logging.getLogger("mecha.spooled_logging_fx")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -180,6 +180,15 @@ def logging_fx(caplog) -> logging.Logger:
 
 
 @pytest.fixture
+def spooled_logging_fx(caplog) -> logging.Logger:
+    """
+    Calls the logging engine with a spooled file for testing strings only.
+    """
+    caplog.clear()
+    return logging.getLogger("mecha.spooled_logging_fx")
+
+
+@pytest.fixture
 def random_string_fx() -> str:
     """
     Creates a 16 digit alphanumeric string.  For use

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -58,6 +58,9 @@ def test_logging_to_file_debug(spooled_logging_fx, tmpdir, random_string_fx, sev
     """
     Test log file input matches written data by logging a random string,
     and then searching that file for the string.
+
+    This test uses a separate file for the string tests, and will not be present in the
+    unit_tests.log file.  This change was requested to fix parallel test execution with xdist.
     """
     test_randstring = random_string_fx
 


### PR DESCRIPTION
As requested, this is a change to the string verification side of the logging tests, so that tests using xdist won't error out due to an inconsistent file IO issue.  No changes to production code on the mecha side included, this is testing only.