### PR TITLE
Use Fuelrats Pydle fork (temporary) - Enables python 3.7 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
           command: |
             python3 -m venv venv
             . venv/bin/activate
-            pip install -r requirements.txt
+            pip install -r requirements.txt --exists-action=w
 
       - run:
           name: Setup Code Climate test-reporter

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
--e git://github.com/Shizmob/pydle.git@asyncio#egg=pydle
+-e git://github.com/FuelRats/pydle.git@asyncio#egg=pydle
 pytest
 pytest-cov
 pytest-asyncio


### PR DESCRIPTION
While the source repo still has 3.7 support pending (as proposed) We can start developing against it