### PR TITLE
Refactor/spark 67

### DIFF
--- a/Modules/context.py
+++ b/Modules/context.py
@@ -139,7 +139,7 @@ class Context(object):
             Context
         """
         # check if the message has our prefix
-        prefixed = prefix in message
+        prefixed = message.startswith(prefix)
 
         # before removing it from the message
         message = message.lstrip(prefix)

--- a/Modules/context.py
+++ b/Modules/context.py
@@ -127,7 +127,8 @@ class Context(object):
     @classmethod
     async def from_message(cls, bot: 'MechaClient', channel: str, sender: str, message: str):
         """
-        Creates a context from a message
+        Creates a context from a IRC message
+
         Args:
             bot (MechaClient): MechaClient instance
             message (str):  raw message

--- a/Modules/context.py
+++ b/Modules/context.py
@@ -10,9 +10,15 @@ Licensed under the BSD 3-Clause License.
 
 See LICENSE.md
 """
-from typing import Optional
+from typing import Optional, Tuple, List, TYPE_CHECKING
 
 from Modules.user import User
+from config import config
+
+if TYPE_CHECKING:
+    from main import MechaClient
+
+prefix = config['commands']['prefix']
 
 
 class Context(object):
@@ -20,7 +26,13 @@ class Context(object):
     Command context, stores the context of a command's invocation
     """
 
-    def __init__(self, bot: 'MechaClient', user: User, target: str, words: [str], words_eol: [str]):
+    def __init__(self, bot: 'MechaClient',
+                 user: User,
+                 target: str,
+                 words: [str],
+                 words_eol: [str],
+                 prefixed: bool = False
+                 ):
         """
         Creates a new Commands Context
 
@@ -30,12 +42,30 @@ class Context(object):
             target(str): channel of invoking channel
             words ([str]): list of words from command invocation
             words_eol ([str]): list of words from command invocation to EOL
+            prefixed (bool): marker if the message is prefixed
         """
         self._user: User = user
         self._bot: 'MechaClient' = bot
         self._target: str = target
         self._words: [str] = words
         self._words_eol: [str] = words_eol
+        self._prefixed: bool = prefixed
+
+    @property
+    def prefixed(self):
+        """
+        Flag marking if the created context is a command/prefixed invocation
+        Returns:
+
+        """
+        return self._prefixed
+
+    @prefixed.setter
+    def prefixed(self, value: bool):
+        if not isinstance(value, bool):
+            raise ValueError
+
+        self._prefixed = value
 
     @property
     def user(self) -> User:
@@ -94,6 +124,33 @@ class Context(object):
         """
         return self.target if self.bot.is_channel(self.target) else None
 
+    @classmethod
+    async def from_message(cls, bot: 'MechaClient', channel: str, sender: str, message: str):
+        """
+        Creates a context from a message
+        Args:
+            bot (MechaClient): MechaClient instance
+            message (str):  raw message
+            sender (str): IRC nickname of the sender
+            channel (str): IRC channel the message was sent from
+
+        Returns:
+            Context
+        """
+        # check if the message has our prefix
+        prefixed = prefix in message
+
+        # before removing it from the message
+        message = message.lstrip(prefix)
+
+        # build the words and words_eol lists
+        words, words_eol = _split_message(message)
+        # get the user from a WHOIS query
+        user = await User.from_whois(bot, sender)
+
+        # return a built context object
+        return cls(bot, user, channel, words, words_eol, prefixed=prefixed)
+
     async def reply(self, msg: str):
         """
         Sends a message in the same channel or query window as the command was sent.
@@ -105,3 +162,37 @@ class Context(object):
             await self.bot.message(self.channel, msg)
         else:
             await self.bot.message(self.user.nickname, msg)
+
+
+def _split_message(string: str) -> Tuple[List[str], List[str]]:
+    """
+    Split up a string into words and words_eol
+
+    Args:
+        string: Any string.
+
+    Returns:
+        (list of str, list of str):
+            A 2-tuple of (words, words_eol), where words is a list of the words of *string*,
+            seperated by whitespace, and words_eol is a list of the same length, with each element
+            including the word and everything up to the end of *string*
+
+    Example:
+        >>> _split_message("pink fluffy unicorns")
+        (['pink', 'fluffy', 'unicorns'], ['pink fluffy unicorns', 'fluffy unicorns', 'unicorns'])
+    """
+    words = []
+    words_eol = []
+    remaining = string
+    while True:
+        words_eol.append(remaining)
+        try:
+            word, remaining = remaining.split(maxsplit=1)
+        except ValueError:
+            # we couldn't split -> only one word left
+            words.append(remaining)
+            break
+        else:
+            words.append(word)
+
+    return words, words_eol

--- a/Modules/context.py
+++ b/Modules/context.py
@@ -60,13 +60,6 @@ class Context(object):
         """
         return self._prefixed
 
-    @prefixed.setter
-    def prefixed(self, value: bool):
-        if not isinstance(value, bool):
-            raise ValueError
-
-        self._prefixed = value
-
     @property
     def user(self) -> User:
         """

--- a/Modules/rat_command.py
+++ b/Modules/rat_command.py
@@ -81,7 +81,7 @@ async def trigger(ctx):
                 log.debug(
                     f"Rule {getattr(command_fun, '__name__', '')} matching {ctx.words[0]} found.")
             else:
-                log.warning(f"Could not find command or rule for {prefix}{ctx.words[0]}.")
+                log.debug(f"Could not find command or rule for {prefix}{ctx.words[0]}.")
     else:
         # Might still be a prefixless rule
         command_fun, extra_args = get_rule(ctx.words, ctx.words_eol, prefixless=True)

--- a/Modules/rat_command.py
+++ b/Modules/rat_command.py
@@ -13,7 +13,7 @@ This module is built on top of the Pydle system.
 """
 
 import logging
-from typing import Callable
+from typing import Callable, Any
 
 from pydle import BasicClient
 
@@ -52,14 +52,14 @@ _registered_commands = {}
 prefix = config['commands']['prefix']
 
 
-async def trigger(ctx):
+async def trigger(ctx) -> Any:
     """
 
     Args:
-        ctx (Context):
+        ctx (Context): Invocation context
 
     Returns:
-
+        result of command execution
     """
 
     if ctx.words_eol[0] == "":

--- a/Modules/rat_command.py
+++ b/Modules/rat_command.py
@@ -13,13 +13,12 @@ This module is built on top of the Pydle system.
 """
 
 import logging
-from typing import Callable, List, Tuple
+from typing import Callable
 
 from pydle import BasicClient
 
 from Modules.context import Context
 from Modules.rules import get_rule, clear_rules
-from Modules.user import User
 from config import config
 
 # set the logger for rat_command
@@ -56,82 +55,45 @@ prefix = config['commands']['prefix']
 bot: BasicClient = None
 
 
-async def trigger(message: str, sender: str, channel: str):
+async def trigger(ctx):
     """
-    Invoke a command, passing args and kwargs to the called function
-    :param message: triggers message to invoke
-    :param sender: author of triggering message
-    :param channel: channel of triggering message
-    :return: bool command
-    """
-    if bot is None:
-        # someone didn't set me.
-        raise CommandException(f"Bot client has not been created"
-                               f" or not handed to Commands.")
-    if message.strip() == "":
-        return
-
-    words, words_eol = _split_message(message.lstrip(prefix))
-    if message.startswith(prefix):
-        if words[0].casefold() in _registered_commands.keys():
-            # A regular command
-            command_fun = _registered_commands[words[0].casefold()]
-            extra_args = ()
-            log.debug(f"Regular command {words[0]} invoked.")
-        else:
-            # Might be a regular rule
-            command_fun, extra_args = get_rule(words, words_eol, prefixless=False)
-            if command_fun:
-                log.debug(f"Rule {getattr(command_fun, '__name__', '')} matching {words[0]} found.")
-            else:
-                log.warning(f"Could not find command or rule for {prefix}{words[0]}.")
-    else:
-        # Might still be a prefixless rule
-        command_fun, extra_args = get_rule(words, words_eol, prefixless=True)
-        if command_fun:
-            log.debug(f"Prefixless rule {getattr(command_fun, '__name__', '')} matching {words[0]} "
-                      f"found.")
-
-    if command_fun:
-        user = await User.from_whois(bot, sender)
-        context = Context(bot, user, channel, words, words_eol)
-        return await command_fun(context, *extra_args)
-    else:
-        log.debug(f"Ignoring message '{message}'. Not a command or rule.")
-
-
-def _split_message(string: str) -> Tuple[List[str], List[str]]:
-    """
-    Split up a string into words and words_eol
 
     Args:
-        string: Any string.
+        ctx (Context):
 
     Returns:
-        (list of str, list of str):
-            A 2-tuple of (words, words_eol), where words is a list of the words of *string*,
-            seperated by whitespace, and words_eol is a list of the same length, with each element
-            including the word and everything up to the end of *string*
 
-    Example:
-        >>> _split_message("pink fluffy unicorns")
-        (['pink', 'fluffy', 'unicorns'], ['pink fluffy unicorns', 'fluffy unicorns', 'unicorns'])
     """
-    words = []
-    words_eol = []
-    remaining = string
-    while True:
-        words_eol.append(remaining)
-        try:
-            word, remaining = remaining.split(maxsplit=1)
-        except ValueError:
-            # we couldn't split -> only one word left
-            words.append(remaining)
-            break
-        else:
-            words.append(word)
 
-    return words, words_eol
+    if ctx.words_eol[0] == "":
+        return  # empty message, bail out
+
+    if ctx.prefixed:
+        if ctx.words[0].casefold() in _registered_commands:
+            # A regular command
+            command_fun = _registered_commands[ctx.words[0].casefold()]
+            extra_args = ()
+            log.debug(f"Regular command {ctx.words[0]} invoked.")
+        else:
+            # Might be a regular rule
+            command_fun, extra_args = get_rule(ctx.words, ctx.words_eol, prefixless=False)
+            if command_fun:
+                log.debug(
+                    f"Rule {getattr(command_fun, '__name__', '')} matching {ctx.words[0]} found.")
+            else:
+                log.warning(f"Could not find command or rule for {prefix}{ctx.words[0]}.")
+    else:
+        # Might still be a prefixless rule
+        command_fun, extra_args = get_rule(ctx.words, ctx.words_eol, prefixless=True)
+        if command_fun:
+            log.debug(
+                f"Prefixless rule {getattr(command_fun, '__name__', '')} matching {ctx.words[0]} "
+                f"found.")
+
+    if command_fun:
+        return await command_fun(ctx, *extra_args)
+    else:
+        log.debug(f"Ignoring message '{ctx.words_eol[0]}'. Not a command or rule.")
 
 
 def _register(func, names: list or str) -> bool:
@@ -198,4 +160,5 @@ def command(*aliases):
         log.debug(f"Registration of {aliases} completed.")
 
         return func
+
     return real_decorator

--- a/Modules/rat_command.py
+++ b/Modules/rat_command.py
@@ -51,9 +51,6 @@ _registered_commands = {}
 # character/s that must prefix a message for it to be parsed as a command.
 prefix = config['commands']['prefix']
 
-# Pydle bot instance.
-bot: BasicClient = None
-
 
 async def trigger(ctx):
     """

--- a/main.py
+++ b/main.py
@@ -164,7 +164,6 @@ async def start():
                          port=config['irc']['port'],
                          tls=config['irc']['tls'])
 
-    rat_command.bot = client
     log.info("Connected to IRC.")
 
 # entry point

--- a/main.py
+++ b/main.py
@@ -82,6 +82,11 @@ class MechaClient(Client):
         :return:
         """
         log.debug(f"{channel}: <{user}> {message}")
+
+        # build context
+        context = await Context.from_message(self, channel, user, message)
+
+
         if user == config['irc']['nickname']:
             # don't do this and the bot can get into an infinite
             # self-stimulated positive feedback loop.
@@ -92,12 +97,8 @@ class MechaClient(Client):
             sanitized_message = sanitize(message)
             log.debug(f"Sanitized {sanitized_message}, Original: {message}")
             try:
-                await rat_command.trigger(message=sanitized_message,
-                                          sender=user,
-                                          channel=channel)
-            except CommandNotFoundException:
-                # command was not found
-                log.debug("Command invoked from \"{message}\" not found.")
+                ctx = await Context.from_message(self, channel, user, message)
+                await rat_command.trigger(ctx)
 
             except Exception as ex:
                 ex_uuid = uuid4()

--- a/main.py
+++ b/main.py
@@ -14,6 +14,7 @@ This module is built on top of the Pydle system.
 """
 import asyncio
 import logging
+from asyncio import AbstractEventLoop
 from uuid import uuid4
 
 from pydle import Client
@@ -143,7 +144,9 @@ async def start():
     """
     Initializes and connects the client, then passes it to rat_command.
     """
-    client_args = {"nickname": config["irc"]["nickname"]}
+    client_args = {"nickname": config["irc"]["nickname"],
+                   # "loop":loop
+                   }
 
     auth_method = config["authentication"]["method"]
     if auth_method == "PLAIN":
@@ -162,7 +165,8 @@ async def start():
     client = MechaClient(**client_args)
     await client.connect(hostname=config['irc']['server'],
                          port=config['irc']['port'],
-                         tls=config['irc']['tls'])
+                         tls=config['irc']['tls'],
+                         )
 
     log.info("Connected to IRC.")
 

--- a/main.py
+++ b/main.py
@@ -83,9 +83,6 @@ class MechaClient(Client):
         """
         log.debug(f"{channel}: <{user}> {message}")
 
-        # build context
-        context = await Context.from_message(self, channel, user, message)
-
         if user == config['irc']['nickname']:
             # don't do this and the bot can get into an infinite
             # self-stimulated positive feedback loop.

--- a/main.py
+++ b/main.py
@@ -84,7 +84,7 @@ class MechaClient(Client):
         log.debug(f"{channel}: <{user}> {message}")
 
         if user == config['irc']['nickname']:
-            # don't do this and the bot can get into an infinite
+            # don't do this and the bot can get int o an infinite
             # self-stimulated positive feedback loop.
             log.debug(f"Ignored {message} (anti-loop)")
             return None
@@ -141,9 +141,7 @@ async def start():
     """
     Initializes and connects the client, then passes it to rat_command.
     """
-    client_args = {"nickname": config["irc"]["nickname"],
-                   # "loop":loop
-                   }
+    client_args = {"nickname": config["irc"]["nickname"]}
 
     auth_method = config["authentication"]["method"]
     if auth_method == "PLAIN":

--- a/main.py
+++ b/main.py
@@ -20,8 +20,7 @@ from pydle import Client
 
 # noinspection PyUnresolvedReferences
 import commands
-from Modules import graceful_errors
-from Modules import rat_command
+from Modules import graceful_errors, rat_command
 from Modules.context import Context
 from Modules.permissions import require_permission, RAT
 from Modules.rat_command import command
@@ -85,7 +84,6 @@ class MechaClient(Client):
 
         # build context
         context = await Context.from_message(self, channel, user, message)
-
 
         if user == config['irc']['nickname']:
             # don't do this and the bot can get into an infinite

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -16,6 +16,7 @@ from Modules.context import Context
 
 pytestmark = pytest.mark.context
 
+
 def test_constructor(bot_fx, user_fx):
     """verifies the constructor functions"""
     my_context = Context(bot_fx, user_fx, "#unittest", ["bird", "is", "the", "word"], [""])
@@ -39,10 +40,47 @@ def test_channel_false(context_pm_fx: Context):
 
 @pytest.mark.asyncio
 async def test_reply(context_fx: Context):
-    """"""
+    """
+    Verifies `context.reply` functions as expected
+
+    Args:
+        context_fx ():
+
+    Returns:
+
+    """
     payload = "This is my reply!!!!"
 
     # make the call
     await context_fx.reply(payload)
 
     assert payload == context_fx.bot.sent_messages[0]['message']
+
+
+@pytest.mark.parametrize("channel, user, message, words, words_eol, prefixed",
+                         [
+                             [
+                                 "#unit_test", "unit_test", "!snafu", ['snafu'], ['snafu'], True
+                             ],
+                             [
+                                 "#ratchat", "some_ov", "!foo bar", ['foo', 'bar'],
+                                 ['foo bar', 'bar'], True
+                             ],
+                             [
+                                 "#unit_test", "unit_test[BOT]", "I wonder...", ["I", "wonder..."],
+                                 ["I wonder...", "wonder..."], False
+                             ]
+                         ])
+@pytest.mark.asyncio
+async def test_from_message(bot_fx, channel, user, message, words, words_eol, prefixed):
+    ctx = await Context.from_message(bot_fx, channel, user, message)
+
+    if prefixed:
+        assert ctx.prefixed
+    else:
+        assert not ctx.prefixed
+
+    assert channel == ctx.channel
+    assert user == ctx.user.nickname
+    assert words == ctx.words
+    assert words_eol == ctx.words_eol

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -69,6 +69,12 @@ async def test_reply(context_fx: Context):
                              [
                                  "#unit_test", "unit_test[BOT]", "I wonder...", ["I", "wonder..."],
                                  ["I wonder...", "wonder..."], False
+                             ],
+                             [
+                                 "#badlands", "some_recruit", "ive been a baad boy!",
+                                 ['ive', 'been', 'a', 'baad', 'boy!'],
+                                 ['ive been a baad boy!', 'been a baad boy!', 'a baad boy!',
+                                  'baad boy!', 'boy!'], False
                              ]
                          ])
 @pytest.mark.asyncio

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -24,14 +24,6 @@ from Modules.context import Context
 from Modules.permissions import require_permission, require_channel, require_dm, Permission
 
 
-# registration is done in setUp
-
-
-# @require_permission(permissions.OVERSEER)
-# async def restricted(context):
-#     await context.reply("Restricted command was executed.")
-
-
 @pytest.fixture
 def Setup_fx(bot_fx):
     """Sets up the test environment"""
@@ -41,10 +33,7 @@ def Setup_fx(bot_fx):
 
 @pytest.fixture
 def restricted_command_fx(async_callable_fx, Setup_fx):
-    # ugly hack to utilize async_callable_fx is ugly
-    @require_permission(permissions.OVERSEER)
-    async def restricted(context):
-        await async_callable_fx(context)
+    restricted = require_permission(permissions.OVERSEER)(async_callable_fx)
 
     Commands.command("restricted")(restricted)
     return async_callable_fx

--- a/tests/test_rat_command.py
+++ b/tests/test_rat_command.py
@@ -134,7 +134,7 @@ class TestRatCommand(object):
         """
         Commands._flush()
         ftrigger = f"!{name} {trigger_message}"
-        words = [f"!{name}"] + trigger_message.split(" ")
+        words = [name] + trigger_message.split(" ")
 
         @Commands.command(name)
         async def the_command(context: Context):

--- a/tests/test_rat_command.py
+++ b/tests/test_rat_command.py
@@ -37,8 +37,8 @@ class TestRatCommand(object):
         """
         Ensures that nothing happens and `trigger` exits quietly when no command can be found.
         """
-        await Commands.trigger(message="!nope", sender="unit_test",
-                               channel="foo")
+        await Commands.trigger(Context(None, None, "#unit_test", ['!unknowncommandsad hi!'],
+                                       ['!unknowncommandsad hi!', "hi!"]))
 
     @pytest.mark.parametrize("alias", ['potato', 'cannon', 'Fodder', 'fireball'])
     def test_double_command_registration(self, alias):
@@ -62,26 +62,25 @@ class TestRatCommand(object):
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("alias", ['potato', 'cannon', 'Fodder', 'fireball'])
-    async def test_call_command(self, alias):
+    async def test_call_command(self, alias, bot_fx):
         """
         Verifiy that found commands can be invoked via Commands.Trigger()
         """
         Commands._flush()
 
         trigger_alias = f"{Commands.prefix}{alias}"
-        input_sender = "unit_test[BOT]"
-        input_channel = "#unit_testing"
 
         @Commands.command(alias)
         async def potato(context: Context):
             # print(f"bot={bot}\tchannel={channel}\tsender={sender}")
             return context.bot, context.channel, context.user.nickname
 
-        out_bot, out_channel, out_sender = await Commands.trigger(
-            message=trigger_alias, sender=input_sender,
-            channel=input_channel)
-        assert input_sender == out_sender
-        assert input_channel == out_channel
+        ctx = await Context.from_message(bot_fx, "#unittest", "unit_test", trigger_alias)
+        retn = await Commands.trigger(ctx)
+        out_bot, out_channel, out_sender = retn
+
+        assert 'unit_test' == out_sender
+        assert "#unittest" == out_channel
 
     @pytest.mark.parametrize("garbage", [12, None, "str"])
     def test_register_non_callable(self, garbage):
@@ -127,7 +126,7 @@ class TestRatCommand(object):
     @pytest.mark.parametrize("name", ("unit_test[BOT]", "some_recruit", "some_ov"))
     @pytest.mark.parametrize("trigger_message", ["salad Baton", "Crunchy Cheddar", "POTATOES!",
                                                  "carrots"])
-    async def test_command_preserves_arguments(self, trigger_message: str, name: str):
+    async def test_command_preserves_arguments(self, trigger_message: str, name: str, bot_fx):
         """
         Verifies commands do not mutate argument words
             - because someone had the bright idea of casting ALL words to lower...
@@ -135,11 +134,12 @@ class TestRatCommand(object):
         """
         Commands._flush()
         ftrigger = f"!{name} {trigger_message}"
-        words = [name] + trigger_message.split(" ")
+        words = [f"!{name}"] + trigger_message.split(" ")
 
         @Commands.command(name)
         async def the_command(context: Context):
             """asserts its arguments equal the outer scope"""
-            assert context.words == words
+            assert words == context.words
 
-        await Commands.trigger(ftrigger, "unit_test[BOT]", "#unit_tests")
+        ctx = await Context.from_message(bot_fx, "#unit_test", "unit_test", ftrigger)
+        await Commands.trigger(ctx)

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -2,7 +2,7 @@ from typing import Match
 
 import pytest
 
-from Modules.context import Context
+from Modules.context import Context, _split_message
 from Modules.rat_command import trigger
 from Modules.rules import rule, clear_rules, RuleNotPresentException, DuplicateRuleException, \
     get_rule
@@ -21,13 +21,18 @@ def clear_rules_fx():
     ("^dabadoop$", False, False, "!DABADOOP"),
     ("na na", False, True, "!na na")
 ])
-async def test_rule_matching(async_callable_fx: AsyncCallableMock, regex: str,
-                             case_sensitive: bool, full_message: bool, message: str):
+async def test_rule_matching(async_callable_fx: AsyncCallableMock,
+                             regex: str,
+                             case_sensitive: bool,
+                             full_message: bool,
+                             message: str,
+                             bot_fx):
     """Verifies that the rule decorator works as expected."""
     rule(regex, case_sensitive=case_sensitive,
          full_message=full_message)(async_callable_fx)
-
-    await trigger(message, "unit_test", "#mordor")
+    ctx = await Context.from_message(bot_fx, "#mordor", "unit_test", message)
+    await trigger(ctx)
+    # await trigger(message, "unit_test", "#mordor")
     assert async_callable_fx.was_called_once
 
 
@@ -39,21 +44,25 @@ async def test_rule_matching(async_callable_fx: AsyncCallableMock, regex: str,
     ("na na", False, False, "!na na")
 ])
 async def test_rule_not_matching(async_callable_fx: AsyncCallableMock, regex: str,
-                                 case_sensitive: bool, full_message: bool, message: str):
+                                 case_sensitive: bool, full_message: bool, message: str, bot_fx):
     """verifies that the rule decorator works as expected."""
     rule(regex, case_sensitive=case_sensitive,
          full_message=full_message)(async_callable_fx)
-    await trigger(message, "unit_test", "theOneWithTheHills")
+    # await trigger(message, "unit_test", "theOneWithTheHills")
+    ctx = await Context.from_message(bot_fx, "#unit_test", "unit_test", message)
+    await trigger(ctx)
     assert not async_callable_fx.was_called
 
 
 @pytest.mark.asyncio
-async def test_rule_passes_match(async_callable_fx: AsyncCallableMock):
+async def test_rule_passes_match(async_callable_fx: AsyncCallableMock, bot_fx):
     """
     Verifies that the rules get passed the match object correctly.
     """
     rule("her(lo)", pass_match=True)(async_callable_fx)
-    await trigger("!herlo", "unit_test", "#unit_test")
+    ctx = await Context.from_message(bot_fx, "#unit_test", "unit_test", "!herlo")
+
+    await trigger(ctx)
 
     assert async_callable_fx.was_called_once
     assert async_callable_fx.was_called_with(InstanceOf(Context), InstanceOf(Match))
@@ -61,12 +70,13 @@ async def test_rule_passes_match(async_callable_fx: AsyncCallableMock):
 
 
 @pytest.mark.asyncio
-async def test_prefixless_rule_called(async_callable_fx: AsyncCallableMock):
+async def test_prefixless_rule_called(async_callable_fx: AsyncCallableMock, bot_fx):
     """
     Verifies that prefixless rules are considered when the prefix is not present.
     """
     rule("da_da(_da)?", prefixless=True)(async_callable_fx)
-    await trigger("da_da", "unit_test", "#unit_test")
+    ctx = await Context.from_message(bot_fx, "#unit_test", "unit_test", "da_da")
+    await trigger(ctx)
 
     assert async_callable_fx.was_called_once
     assert async_callable_fx.was_called_with(InstanceOf(Context))
@@ -78,12 +88,14 @@ async def test_prefixless_rule_called(async_callable_fx: AsyncCallableMock):
     ("!woof", "!woof woof")
 ])
 async def test_prefixless_rule_not_called(regex: str, message: str,
-                                          async_callable_fx: AsyncCallableMock):
+                                          async_callable_fx: AsyncCallableMock, bot_fx):
     """
     Verifies that prefixless rules are not considered if the prefix is present.
     """
     rule(regex, prefixless=True)(async_callable_fx)
-    await trigger(message, "unit_test", "#unit_test")
+
+    ctx = await Context.from_message(bot_fx, "#unit_test", "unit_test", message)
+    await trigger(ctx)
 
     assert not async_callable_fx.was_called
 
@@ -134,7 +146,7 @@ async def test_rule_callable(callable_fx: CallableMock):
 
 
 @pytest.mark.asyncio
-async def test_rule_after():
+async def test_rule_after(bot_fx):
     """
     Ensures that the *after* parameter behaves as expected.
     This is rather useless as the order in which the rules are registered already ensures their
@@ -146,7 +158,10 @@ async def test_rule_after():
     rule1 = rule("gaah")(async_callable_1)
     rule2 = rule("(g|b)aah", after=rule1)(async_callable_2)
 
-    await trigger("!gaah", "unit_test", "#channel")
+    ctx = await Context.from_message(bot_fx, "#channel", "unit_test", "!gaah")
+
+    await trigger(ctx)
+
     assert async_callable_1.was_called_once
     assert not async_callable_2.was_called
 


### PR DESCRIPTION
This PR implements SPARK-67

# Main Effects:
- The creation of `Context` has been moved to `MechaClient.on_message`
`rat_command.trigger()` 's signature has been changed to `trigger(ctx: Context)`

- `rat_command.bot` has been nuked from orbit. We don't need it any more

## Secondary Effects
- `rat_command._split_message` was moved to `context._split_message`
This was done as to keep it to where it is used. it is not generic enough to warrant moving to our shared library file. 

- `Context` now has a new instance property, `prefixed`
This boolean flag is used to indicate the message started with the bots command prefix
This was necessary as not to change the established behavior of `_split_message` and `Context` respectively

- `Context` now has a new async classmethod: `Context.from_message`
This method is used to process a raw irc message, channel, and sender into a Context object
It needs to be async due to the WHOIS lookup call necessary for the `Context` constructor.

### Reasoning

The primary motivation for this was removing `rat_command.bot` module attribute, it was a ugly hack that can now be removed in favor of something cleaner.

Other events, such as `on_message_raw` can make use of the context variable, which is currently locked into `rat_command.trigger()` meaning they have to use the `MechaClient.on_message(target, sender, message)` signature and do their own message processing. 

By moving the Context creation into `on_message` the context can be used by any function it calls. This standardizes any event dependent on an IRC message by giving it its own class.

