### PR TITLE
Make the MockBot a subclass of the MechaClient

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,10 +19,9 @@ from uuid import uuid4, UUID
 
 import pytest
 
-# Set argv to keep cli arguments meant for pytest from polluting our things
-
-
 from Modules.rat_cache import RatCache
+
+# Set argv to keep cli arguments meant for pytest from polluting our things
 
 sys.argv = ["test",
             "--config-file", "testing.json",
@@ -116,7 +115,7 @@ def rat_board_fx() -> RatBoard:
 
 @pytest.fixture
 def bot_fx():
-    return MockBot()
+    return MockBot(nickname="mock_mecha3[BOT]")
 
 
 @pytest.fixture

--- a/tests/mock_bot.py
+++ b/tests/mock_bot.py
@@ -1,4 +1,6 @@
-class MockBot(object):
+from main import MechaClient
+
+class MockBot(MechaClient):
     """Emulates some of the bots functions for testing purposes."""
 
     def __init__(self):

--- a/tests/mock_bot.py
+++ b/tests/mock_bot.py
@@ -1,9 +1,12 @@
 from main import MechaClient
 
+
 class MockBot(MechaClient):
     """Emulates some of the bots functions for testing purposes."""
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
+        # lets ensure the super gets called first, before we start overriding things
+        super().__init__(*args, **kwargs)
         self.sent_messages = []
         self.users = {
             "unit_test[BOT]": {'oper': False,
@@ -109,3 +112,7 @@ class MockBot(MechaClient):
     @classmethod
     def is_channel(cls, channel: str):
         return channel[0] in ("#", "&")
+
+    async def connect(self):
+        """Pydle connect override to prevent the mock accidently connecting to a server"""
+        raise RuntimeWarning("Connection to a server disallowed in instances of the mock bot.")


### PR DESCRIPTION
This PR makes the `MockBot` class a subclass of the `MechaClient`.

The primary motivation here is to enable the usage of the mock bot's overriden methods while calling methods on the MechaClient instance. For instance, in SPARK-50 i need to call Mechaclient methods to verify their function, which in turn call methods overriden in MockBot. For these tests, i am testing the implementation of the Mechaclient method, not the pydle back end. Therefore being able to easily mock out the `whois` method is of value.

Since the MockBot is provided as a facility to mock certain Mechaclient calls for the sake of testing, it makes sense to have it simply extend and override the corresponding methods in the Mechaclient.


This change does not break existing tests, nor requires any rework of them.

This change facilitates testing the MechaClient