### PR TITLE
SPARK-70 Open the config file with UTF8 encoding

### DIFF
--- a/config.py
+++ b/config.py
@@ -112,7 +112,7 @@ def setup(filename: str) -> None:
     # check if the file exists
     if os.path.exists(path):
         logging.info(f"Found a file/directory at {filename}'! attempting to load...")
-        with open(path, 'r') as infile:
+        with open(path, 'r', encoding="UTF8") as infile:
             config_dict = json.load(infile)
             logging.info("Successfully loaded JSON from file specified!")
 


### PR DESCRIPTION
Resolves SPARK-70
Default encoding does not properly support "extended characters" which can lead to undocumented behavior in mecha3 relating to config file contents.
The solution is as simple as specifying UTF8 as the file format during the open() call.