### PR TITLE
SPARK-71 Fixed faulty command prefix processing in Context

### DIFF
--- a/Modules/context.py
+++ b/Modules/context.py
@@ -134,8 +134,9 @@ class Context(object):
         # check if the message has our prefix
         prefixed = message.startswith(prefix)
 
-        # before removing it from the message
-        message = message.lstrip(prefix)
+        if prefixed:
+            # before removing it from the message
+            message = message[len(prefix):]
 
         # build the words and words_eol lists
         words, words_eol = _split_message(message)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 markers =
+    regressions: Regression tests
     database: marks a test as a database test
     rat: marks a test as being a rats test
     api: marks a test as being an API test

--- a/tests/regressions/test_context_regressions.py
+++ b/tests/regressions/test_context_regressions.py
@@ -1,0 +1,36 @@
+"""
+PyTest module for Context-specific regressions
+"""
+
+from pytest import mark
+
+from Modules import rat_command
+from Modules.context import Context
+from Modules.rat_command import command, prefix
+from Modules.user import User
+
+
+@mark.asyncio
+@mark.regressions
+async def test_on_command_double_prefix(bot_fx, monkeypatch, context_fx, async_callable_fx):
+    """
+    Verifies that when commands are prefixed with the command prefix during registration,
+    they remain invokable during runtime.
+    """
+    async_callable_fx.return_value = context_fx.user
+
+    # patch the whois lookup as its outside the scope of our test.
+    monkeypatch.setattr(User, "from_whois", async_callable_fx)
+
+    ctx = await Context.from_message(bot_fx, "#unit_test", context_fx.user.nickname,
+
+                                     f"{prefix}{prefix}boom")
+
+    monkeypatch.setattr(rat_command, "_registered_commands", dict())
+
+    @command(f"{prefix}boom")
+    async def cmd_boom(context: Context):
+        return 42
+
+    result = await rat_command.trigger(ctx=ctx)
+    assert 42 == result


### PR DESCRIPTION
This PR resolves SPARK-71 by correcting Context's prefix processing.

Context will now only strip exactly the command prefix from the start of the message leaving any subsequent characters (such as the command-prefix being used improperly)

This PR also adds a test module for regression tests, which can be used to house further regression tests as more bugs are detected and fixed.
Further, I have added a pytest marker for regression tests, so they can be run independently from the rest of the test suite.

End result: if our command prefix is `!`, commands such as `!bang` will now behave as expected, 
```
<unknown> !!bang
<Mechasqueak3-tests[BOT]> boom!
<unknown> good.
```