### PR TITLE
[Testing/bugfix]Manually specify our testing directory

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -18,3 +18,5 @@ markers =
     ratlib: marks a test as a ratlib test
     setup_tests: setup test marker
     graceful_error: 'graceful_error' tests
+
+addopts = tests


### PR DESCRIPTION
Apparently Pydle's test suite gets detected by PyTest in some configurations, which leads to bad things.
I added a line to the `pytest.ini` configuration file as to manually specify our `tests/` directory as the test discovery root. This prevents pytest from trying to run dependencies' test suite(s).