### PR TITLE
SPARK-80 Use the sanitized message object for context creation 

### DIFF
--- a/main.py
+++ b/main.py
@@ -93,7 +93,7 @@ class MechaClient(Client):
             sanitized_message = sanitize(message)
             log.debug(f"Sanitized {sanitized_message}, Original: {message}")
             try:
-                ctx = await Context.from_message(self, channel, user, message)
+                ctx = await Context.from_message(self, channel, user, sanitized_message)
                 await rat_command.trigger(ctx)
 
             except Exception as ex:


### PR DESCRIPTION
mistooks were made.

We should not be passing the original message into context creation, but the sanetitized version.
Presently we sanetrize the message but discard the result erroneously. this pr fixes that