### PR TITLE
Rise of the ContextVar, fall of `Context`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
     docker:
       # specify the version you desire here
       # use `-browsers` prefix for selenium tests, e.g. `3.6.1-browsers`
-      - image: circleci/python:3.6.6
+      - image: circleci/python:3.7.1
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images

--- a/Modules/context.py
+++ b/Modules/context.py
@@ -127,34 +127,32 @@ class Context(object):
         """
         return self.target if self.bot.is_channel(self.target) else None
 
-    @classmethod
-    async def from_message(cls):
-        """
-        Creates a context from a IRC message
 
-        Args:
+def from_message():
+    """
+    Populates the context from a IRC message
+    """
+    _message = message.get()
+    _bot = bot.get()
+    # check if the message has our prefix
+    _prefixed = _message.startswith(prefix)
 
-        Returns:
-            Context
-        """
-        # check if the message has our prefix
-        prefixed.set(message.get().startswith(prefix))
+    if _prefixed:
+        prefixed.set(_message.startswith(prefix))
+        # before removing it from the message
+        _message = _message[len(prefix):]
+        message.set(_message)
 
-        if prefixed.get():
-            # before removing it from the message
-            message.set(message.get()[len(prefix):])
+    # build the words and words_eol lists
+    _words, _words_eol = _split_message(_message)
+    words.set(_words)
+    words_eol.set(_words_eol)
+    # get the user from a WHOIS query
 
-        # build the words and words_eol lists
-        _words, _words_eol = _split_message(message.get())
-
-        words.set(_words)
-        words_eol.set(_words_eol)
-        # get the user from a WHOIS query
-        user.set(User.from_pydle(bot.get(), sender.get()))
-
-        # determine if we were in a channel
-        if bot.get().is_channel(target.get()):
-            channel.set(target.get())
+    user.set(User.from_pydle(_bot, sender.get()))
+    # determine if we were in a channel
+    if _bot.is_channel(target.get()):
+        channel.set(target.get())
 
 
 async def reply(msg: str):

--- a/Modules/context/__init__.py
+++ b/Modules/context/__init__.py
@@ -1,0 +1,29 @@
+"""
+__init__.py.py - Context-sensitive variables
+
+Provides an interface for tending to context-sensitive data such as cross-function execution context
+
+Copyright (c) 2018 The Fuel Rats Mischief,
+All rights reserved.
+
+Licensed under the BSD 3-Clause License.
+
+See LICENSE.md
+"""
+
+from ._context import message, user, target, channel, prefixed, bot, words_eol, words, sender, \
+    from_message, reply
+
+__all__ = [
+    "message",
+    'user',
+    'target',
+    'channel',
+    'prefixed',
+    'bot',
+    'words',
+    'words_eol',
+    'sender',
+    'from_message',
+    'reply'
+]

--- a/Modules/context/_context.py
+++ b/Modules/context/_context.py
@@ -1,7 +1,7 @@
 """
-context.py - Command contexts
+_context.py - Command contexts
 
-Provides a context object for use with commands
+Provides Context Variables and context-sensitive utilities
 
 Copyright (c) 2018 The Fuel Rat Mischief,
 All rights reserved.
@@ -28,119 +28,22 @@ message: ContextVar[str] = ContextVar('message')
 bot: ContextVar['MechaClient'] = ContextVar('bot')
 sender: ContextVar[str] = ContextVar('sender')
 
-prefix = config['commands']['prefix']
+_prefix = config['commands']['prefix']
 
 
-class Context(object):
-    """
-    Command context, stores the context of a command's invocation
-    """
-
-    def __init__(self, bot: 'MechaClient',
-                 user: User,
-                 target: str,
-                 words: [str],
-                 words_eol: [str],
-                 prefixed: bool = False
-                 ):
-        """
-        Creates a new Commands Context
-
-        Args:
-            user (User): invoking IRC user
-            bot (MechaClient): Mechaclient instance
-            target(str): channel of invoking channel
-            words ([str]): list of words from command invocation
-            words_eol ([str]): list of words from command invocation to EOL
-            prefixed (bool): marker if the message is prefixed
-        """
-        self._user: User = user
-        self._bot: 'MechaClient' = bot
-        self._target: str = target
-        self._words: [str] = words
-        self._words_eol: [str] = words_eol
-        self._prefixed: bool = prefixed
-
-    @property
-    def prefixed(self):
-        """
-        Flag marking if the created context is a command/prefixed invocation
-        Returns:
-
-        """
-        return self._prefixed
-
-    @property
-    def user(self) -> User:
-        """
-        IRC user instance
-
-        Returns:
-            User
-        """
-        return self._user
-
-    @property
-    def bot(self) -> 'MechaClient':
-        """
-        MechaClient instance
-
-        Returns:
-            MechaClient
-        """
-        return self._bot
-
-    @property
-    def words(self) -> [str]:
-        """
-        words in invoking message
-
-        Returns:
-            list[str]: list of words
-        """
-        return self._words
-
-    @property
-    def words_eol(self) -> [str]:
-        """
-        Words in invoking message to EOL
-
-        Returns:
-            list[str]
-        """
-        return self._words_eol
-
-    @property
-    def target(self) -> str:
-        """
-        Target of command invocation
-
-        Returns:
-            str
-        """
-        return self._target
-
-    @property
-    def channel(self) -> Optional[str]:
-        """
-        If the message was sent in a channel, this will be its name and `None` otherwise.
-        """
-        return self.target if self.bot.is_channel(self.target) else None
-
-
-def from_message():
+async def from_message():
     """
     Populates the context from a IRC message
     """
     _message = message.get()
     _bot = bot.get()
     # check if the message has our prefix
-    _prefixed = _message.startswith(prefix)
+    _prefixed = _message.startswith(_prefix)
 
     if _prefixed:
-        prefixed.set(_message.startswith(prefix))
+        prefixed.set(_message.startswith(_prefix))
         # before removing it from the message
-        _message = _message[len(prefix):]
+        _message = _message[len(_prefix):]
         message.set(_message)
 
     # build the words and words_eol lists

--- a/Modules/permissions.py
+++ b/Modules/permissions.py
@@ -15,7 +15,6 @@ import logging
 from functools import wraps
 from typing import Any, Union, Callable, List, Dict, Set
 
-from Modules.context import Context
 from Modules import context
 from config import config
 
@@ -250,15 +249,15 @@ def require_channel(func: Union[str, Callable] = None,
 
     Usage:
         >>> @require_channel
-        ... async def my_command(context: Context):
+        ... async def my_command():
         ...     pass
 
         >>> @require_channel("access denied.")
-        ... async def my_command(context: Context):
+        ... async def my_command():
         ...     pass
 
         >>> @require_channel(_message="access denied.")
-        ... async def my_command(context: Context):
+        ... async def my_command():
         ...     pass
     """
     # form of @decorator("message") and @decorator(message=str)
@@ -320,15 +319,15 @@ def require_dm(func: Union[str, Callable] = None,
 
     Usage:
         >>> @require_dm
-        ... async def my_command(context: Context):
+        ... async def my_command():
         ...     pass
 
         >>> @require_dm("access denied.")
-        ... async def my_command(context: Context):
+        ... async def my_command():
         ...     pass
 
         >>> @require_dm(message="access denied.")
-        ... async def my_command(context: Context):
+        ... async def my_command():
         ...     pass
     """
     # form of @decorator("message") and @decorator(message=str)

--- a/Modules/rat_command.py
+++ b/Modules/rat_command.py
@@ -60,7 +60,7 @@ async def trigger() -> Any:
     if words_eol.get()[0] == "":
         return  # empty message, bail out
 
-    if prefixed:
+    if prefixed.get():
         if words.get()[0].casefold() in _registered_commands:
             # A regular command
             command_fun = _registered_commands[words.get()[0].casefold()]
@@ -76,7 +76,7 @@ async def trigger() -> Any:
                 log.debug(f"Could not find command or rule for {prefix}{words.get()[0]}.")
     else:
         # Might still be a prefixless rule
-        command_fun, extra_args = get_rule(words, words_eol, prefixless=True)
+        command_fun, extra_args = get_rule(words.get(), words_eol.get(), prefixless=True)
         if command_fun:
             log.debug(
                 f"Prefixless rule {getattr(command_fun, '__name__', '')} matching {words.get()[0]} "

--- a/Modules/rat_quotation.py
+++ b/Modules/rat_quotation.py
@@ -1,7 +1,7 @@
 import logging
 from datetime import datetime
 
-from Modules.context import Context
+from Modules import context
 from config import config
 
 log = logging.getLogger(f"mecha.{__name__}")
@@ -134,7 +134,7 @@ class Quotation(object):
         else:
             raise ValueError(f"Expected string got {type(value)}")
 
-    def modify(self, context: Context, message: str) -> None:
+    def modify(self, message: str) -> None:
         """
         Helper method for modifying a quote
 
@@ -147,4 +147,4 @@ class Quotation(object):
         """
         self._message = message
         self._updated_at = datetime.utcnow()
-        self._last_author = context.user.nickname
+        self._last_author = context.user.get().nickname

--- a/Modules/user.py
+++ b/Modules/user.py
@@ -134,7 +134,7 @@ class User(object):
         return self._nickname
 
     @classmethod
-    async def from_pydle(cls, bot: BasicClient, nickname: str) -> Optional['User']:
+    def from_pydle(cls, bot: BasicClient, nickname: str) -> Optional['User']:
         """
         Returns a user object from pydle's backend
 

--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-pydle = {editable = true, ref = "pydle-2", git = "git://github.com/theunkn0wn1/pydle.git"}
+pydle = ">=0.8.5"
 pure-sasl = "*"
 coloredlogs = "*"
 

--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-pydle = {editable = true, ref = "asyncio", git = "git://github.com/Shizmob/pydle.git"}
+pydle = {editable = true, ref = "pydle-2", git = "git://github.com/theunkn0wn1/pydle.git"}
 pure-sasl = "*"
 coloredlogs = "*"
 
@@ -14,4 +14,4 @@ pytest-cov = "*"
 pytest-asyncio = "*"
 
 [requires]
-python_version = "3.6"
+python_version = "3.7"

--- a/Pipfile
+++ b/Pipfile
@@ -12,6 +12,7 @@ coloredlogs = "*"
 pytest = "*"
 pytest-cov = "*"
 pytest-asyncio = "*"
+ipython = "*"
 
 [requires]
-python_version = "3.7"
+python_version = "3.7.1"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "6b4d5fc4e433cf421e3f2d128457615ecaacf55682352d77e083f8905e43e94d"
+            "sha256": "e18a3ea4c4b30a9b064f6015d093d7e446245b464b90954ea634a0e2ca4d1e8d"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.7"
+            "python_version": "3.7.1"
         },
         "sources": [
             {
@@ -75,6 +75,13 @@
             ],
             "version": "==18.2.0"
         },
+        "backcall": {
+            "hashes": [
+                "sha256:38ecd85be2c1e78f77fd91700c76e14667dc21e2713b63876c0eb901196e01e4",
+                "sha256:bbbf4b1e5cd2bdb08f915895b51081c041bac22394fdfcfdfbe9f14b77c08bf2"
+            ],
+            "version": "==0.1.0"
+        },
         "colorama": {
             "hashes": [
                 "sha256:05eed71e2e327246ad6b38c540c4a3117230b19679b875190486ddd2d721422d",
@@ -119,6 +126,35 @@
             ],
             "version": "==4.5.2"
         },
+        "decorator": {
+            "hashes": [
+                "sha256:2c51dff8ef3c447388fe5e4453d24a2bf128d3a4c32af3fabef1f01c6851ab82",
+                "sha256:c39efa13fbdeb4506c476c9b3babf6a718da943dab7811c206005a4a956c080c"
+            ],
+            "version": "==4.3.0"
+        },
+        "ipython": {
+            "hashes": [
+                "sha256:6a9496209b76463f1dec126ab928919aaf1f55b38beb9219af3fe202f6bbdd12",
+                "sha256:f69932b1e806b38a7818d9a1e918e5821b685715040b48e59c657b3c7961b742"
+            ],
+            "index": "pypi",
+            "version": "==7.2.0"
+        },
+        "ipython-genutils": {
+            "hashes": [
+                "sha256:72dd37233799e619666c9f639a9da83c34013a73e8bbc79a7a6348d93c61fab8",
+                "sha256:eb2e116e75ecef9d4d228fdc66af54269afa26ab4463042e33785b887c628ba8"
+            ],
+            "version": "==0.2.0"
+        },
+        "jedi": {
+            "hashes": [
+                "sha256:571702b5bd167911fe9036e5039ba67f820d6502832285cde8c881ab2b2149fd",
+                "sha256:c8481b5e59d34a5c7c42e98f6625e633f6ef59353abea6437472c7ec2093f191"
+            ],
+            "version": "==0.13.2"
+        },
         "more-itertools": {
             "hashes": [
                 "sha256:c187a73da93e7a8acc0001572aebc7e3c69daf7bf6881a2cea10650bd4420092",
@@ -127,6 +163,20 @@
             ],
             "version": "==4.3.0"
         },
+        "parso": {
+            "hashes": [
+                "sha256:35704a43a3c113cce4de228ddb39aab374b8004f4f2407d070b6a2ca784ce8a2",
+                "sha256:895c63e93b94ac1e1690f5fdd40b65f07c8171e3e53cbd7793b5b96c0e0a7f24"
+            ],
+            "version": "==0.3.1"
+        },
+        "pickleshare": {
+            "hashes": [
+                "sha256:87683d47965c1da65cdacaf31c8441d12b8044cdec9aca500cd78fc2c683afca",
+                "sha256:9649af414d74d4df115d5d718f82acb59c9d418196b7b4290ed47a12ce62df56"
+            ],
+            "version": "==0.7.5"
+        },
         "pluggy": {
             "hashes": [
                 "sha256:447ba94990e8014ee25ec853339faf7b0fc8050cdc3289d4d71f7f410fb90095",
@@ -134,12 +184,27 @@
             ],
             "version": "==0.8.0"
         },
+        "prompt-toolkit": {
+            "hashes": [
+                "sha256:c1d6aff5252ab2ef391c2fe498ed8c088066f66bc64a8d5c095bbf795d9fec34",
+                "sha256:d4c47f79b635a0e70b84fdb97ebd9a274203706b1ee5ed44c10da62755cf3ec9",
+                "sha256:fd17048d8335c1e6d5ee403c3569953ba3eb8555d710bfc548faf0712666ea39"
+            ],
+            "version": "==2.0.7"
+        },
         "py": {
             "hashes": [
                 "sha256:bf92637198836372b520efcba9e020c330123be8ce527e535d185ed4b6f45694",
                 "sha256:e76826342cefe3c3d5f7e8ee4316b80d1dd8a300781612ddbc765c17ba25a6c6"
             ],
             "version": "==1.7.0"
+        },
+        "pygments": {
+            "hashes": [
+                "sha256:5ffada19f6203563680669ee7f53b64dabbeb100eb51b61996085e99c03b284a",
+                "sha256:e8218dd399a61674745138520d0d4cf2621d7e032439341bc3f647bff125818d"
+            ],
+            "version": "==2.3.1"
         },
         "pytest": {
             "hashes": [
@@ -171,6 +236,20 @@
                 "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
             ],
             "version": "==1.12.0"
+        },
+        "traitlets": {
+            "hashes": [
+                "sha256:9c4bd2d267b7153df9152698efb1050a5d84982d3384a37b2c1f7723ba3e7835",
+                "sha256:c6cb5e6f57c5a9bdaa40fa71ce7b4af30298fbab9ece9815b5d995ab6217c7d9"
+            ],
+            "version": "==4.3.2"
+        },
+        "wcwidth": {
+            "hashes": [
+                "sha256:3df37372226d6e63e1b1e1eda15c594bca98a22d33a23832a90998faa96bc65e",
+                "sha256:f4ebe71925af7b40a864553f761ed559b43544f8f71746c2d756c7fe788ade7c"
+            ],
+            "version": "==0.1.7"
         }
     }
 }

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e18a3ea4c4b30a9b064f6015d093d7e446245b464b90954ea634a0e2ca4d1e8d"
+            "sha256": "39369e34cbf8a15001c5acd3bca359b30c1f3f27aaa430bf9c6c4a1f0e48caf3"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -48,9 +48,12 @@
             "version": "==0.5.1"
         },
         "pydle": {
-            "editable": true,
-            "git": "git://github.com/theunkn0wn1/pydle.git",
-            "ref": "3e1aa27a1f40e16092d8f4d29863a057ee27d2ff"
+            "hashes": [
+                "sha256:046c16ac119734cde969e5519255a9e4eae98976cf5262e13975aeb219041b2a",
+                "sha256:d801b03d902b0265fe4c7450b8880d7a01e424cbc985edf578a610c5cdbce75a"
+            ],
+            "index": "pypi",
+            "version": "==0.8.5"
         },
         "pyreadline": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "75d3cc3f78b400e3e423aaf7d126023a1394b2d877173d913dcb7bbdaa76fa09"
+            "sha256": "6b4d5fc4e433cf421e3f2d128457615ecaacf55682352d77e083f8905e43e94d"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.6"
+            "python_version": "3.7"
         },
         "sources": [
             {
@@ -49,8 +49,8 @@
         },
         "pydle": {
             "editable": true,
-            "git": "git://github.com/Shizmob/pydle.git",
-            "ref": "b9517071e42c601fd2b7c90f5823c098cd3e6d33"
+            "git": "git://github.com/theunkn0wn1/pydle.git",
+            "ref": "3e1aa27a1f40e16092d8f4d29863a057ee27d2ff"
         },
         "pyreadline": {
             "hashes": [
@@ -143,11 +143,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:1d131cc532be0023ef8ae265e2a779938d0619bb6c2510f52987ffcba7fa1ee4",
-                "sha256:ca4761407f1acc85ffd1609f464ca20bb71a767803505bd4127d0e45c5a50e23"
+                "sha256:f689bf2fc18c4585403348dd56f47d87780bf217c53ed9ae7a3e2d7faa45f8e9",
+                "sha256:f812ea39a0153566be53d88f8de94839db1e8a05352ed8a49525d7d7f37861e9"
             ],
             "index": "pypi",
-            "version": "==4.0.1"
+            "version": "==4.0.2"
         },
         "pytest-asyncio": {
             "hashes": [
@@ -167,10 +167,10 @@
         },
         "six": {
             "hashes": [
-                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",
-                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
+                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
+                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
             ],
-            "version": "==1.11.0"
+            "version": "==1.12.0"
         }
     }
 }

--- a/commands/debug.py
+++ b/commands/debug.py
@@ -13,7 +13,7 @@ See LICENSE.md
 """
 import logging
 
-from Modules.context import Context
+from Modules import context
 from Modules.permissions import require_permission, TECHRAT, require_channel
 from Modules.rat_command import command
 
@@ -37,5 +37,5 @@ async def cmd_debug_whois(context):
 @command("superPing!")
 @require_channel
 @require_permission(TECHRAT)
-async def cmd_superping(context: Context):
+async def cmd_superping():
     await context.reply("pong!")

--- a/commands/debug.py
+++ b/commands/debug.py
@@ -23,13 +23,13 @@ log = logging.getLogger(f"mecha.{__name__}")
 @command("debug-whois")
 @require_channel
 @require_permission(TECHRAT)
-async def cmd_debug_whois(context):
+async def cmd_debug_whois():
     """A debug command for running a WHOIS command.
 
     Returns
         str: string repreentation
     """
-    data = await context.bot.whois(context.words[1])
+    data = await context.bot.get().whois(context.words.get()[1])
     log.debug(data)
     await context.reply(f"{data}")
 

--- a/main.py
+++ b/main.py
@@ -82,8 +82,6 @@ class MechaClient(Client):
         """
         log.debug(f"{channel}: <{user}> {message}")
 
-
-
         if user == config['irc']['nickname']:
             # don't do this and the bot can get int o an infinite
             # self-stimulated positive feedback loop.

--- a/main.py
+++ b/main.py
@@ -93,7 +93,7 @@ class MechaClient(Client):
             sanitized_message = sanitize(message)
             log.debug(f"Sanitized {sanitized_message}, Original: {message}")
             try:
-                ctx = await Context.from_message(self, channel, user, message)
+                ctx = await Context.from_message(self, channel, user, sanitized_message)
                 await rat_command.trigger(ctx)
 
             except Exception as ex:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -115,7 +115,11 @@ def rat_board_fx() -> RatBoard:
 
 @pytest.fixture
 def bot_fx():
-    return MockBot(nickname="mock_mecha3[BOT]")
+
+    bot = MockBot(nickname="mock_mecha3[BOT]")
+
+    bot.nickname = "mock_mecha3[BOT]"
+    return bot
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,7 +40,7 @@ from Modules.rat_board import RatBoard
 from Modules.rat_rescue import Rescue
 from Modules.rat import Rat
 from utils.ratlib import Platforms
-from Modules.context import Context
+from Modules import context
 from Modules.epic import Epic
 from Modules.user import User
 from Modules.mark_for_deletion import MarkForDeletion
@@ -131,39 +131,28 @@ def user_fx():
                 )
 
 
-@pytest.fixture
-def context_channel_fx(user_fx, bot_fx) -> Context:
-    """
-    Provides a context fixture
-
-    Returns:
-        Context
-    """
-    context = Context(bot_fx, user_fx, "#unit_test", ["my", "word"], ["my", "my word"])
-    return context
-
-
-@pytest.fixture
-def context_pm_fx(user_fx, bot_fx) -> Context:
-    """
-    Provides a context fixture
-
-    Returns:
-        Context
-    """
-    context = Context(bot_fx, user_fx, "someUSer", ["my", "word"], ["my", "my word"])
-    return context
-
-
 @pytest.fixture(params=[0, 1])
 def context_fx(request, bot_fx, user_fx):
     """Parametrized context fixture, returning a channel and non-channel Context object"""
     if request.param == 0:
-        return Context(bot_fx, user_fx, "#unit_test", ["my", "word"], ["my", "my word"])
-    elif request.param == 1:
-        return Context(bot_fx, user_fx, "someUSer", ["my", "word"], ["my", "my word"])
+        context.bot.set(bot_fx)
+        context.sender.set(user_fx.nickname)
+        context.user.set(user_fx)
+        context.target.set("#unit_test")
+        context.channel.set("#unit_test")
+        context.words.set(["my", "word"])
+        context.words_eol.set(["my word", "word"])
 
-    raise ValueError
+    elif request.param == 1:
+        context.sender.set(user_fx.nickname)
+        context.bot.set(bot_fx)
+        context.user.set(user_fx)
+        context.target.set("pmContextTArget")
+        context.words.set(["my", "word"])
+        context.words_eol.set(["my word", "word"])
+
+    else:
+        raise ValueError
 
 
 @pytest.fixture
@@ -235,6 +224,7 @@ def reset_rat_cache_fx(rat_cache_fx: RatCache):
     # and clean up after ourselves
     rat_cache_fx.flush()
 
+
 @pytest.fixture
 def permission_fx(monkeypatch) -> Permission:
     """
@@ -250,6 +240,7 @@ def permission_fx(monkeypatch) -> Permission:
     monkeypatch.setattr("Modules.permissions._by_vhost", {})
     permission = Permission(0, {"testing.fuelrats.com", "cheddar.fuelrats.com"})
     return permission
+
 
 @pytest.fixture
 def callable_fx():

--- a/tests/regressions/test_context_regressions.py
+++ b/tests/regressions/test_context_regressions.py
@@ -22,9 +22,7 @@ async def test_on_command_double_prefix(bot_fx, monkeypatch, context_fx, async_c
     # patch the whois lookup as its outside the scope of our test.
     monkeypatch.setattr(User, "from_pydle", async_callable_fx)
 
-    ctx = await Context.from_message(bot_fx, "#unit_test", context_fx.user.nickname,
-
-                                     f"{prefix}{prefix}boom")
+    ctx = await Context.from_message()
 
     monkeypatch.setattr(rat_command, "_registered_commands", dict())
 
@@ -32,5 +30,5 @@ async def test_on_command_double_prefix(bot_fx, monkeypatch, context_fx, async_c
     async def cmd_boom(context: Context):
         return 42
 
-    result = await rat_command.trigger(ctx=ctx)
+    result = await rat_command.trigger()
     assert 42 == result

--- a/tests/regressions/test_context_regressions.py
+++ b/tests/regressions/test_context_regressions.py
@@ -4,30 +4,30 @@ PyTest module for Context-specific regressions
 
 from pytest import mark
 
-from Modules import rat_command
-from Modules.context import Context
+from Modules import rat_command, context
 from Modules.rat_command import command, prefix
-from Modules.user import User
 
 
 @mark.asyncio
 @mark.regressions
-async def test_on_command_double_prefix(bot_fx, monkeypatch, context_fx, async_callable_fx):
+async def test_on_command_double_prefix(bot_fx, monkeypatch, context_fx, async_callable_fx,
+                                        user_fx):
     """
     Verifies that when commands are prefixed with the command prefix during registration,
     they remain invokable during runtime.
     """
-    async_callable_fx.return_value = context_fx.user
 
-    # patch the whois lookup as its outside the scope of our test.
-    monkeypatch.setattr(User, "from_pydle", async_callable_fx)
-
-    ctx = await Context.from_message()
+    context.sender.set(user_fx.nickname)
+    context.user.set(user_fx)
+    context.prefixed.set(True)
+    context.message = f"{prefix}{prefix}boom"
+    context.words.set([f"{prefix}boom"])
+    context.words_eol.set([f'{prefix}boom'])
 
     monkeypatch.setattr(rat_command, "_registered_commands", dict())
 
     @command(f"{prefix}boom")
-    async def cmd_boom(context: Context):
+    async def cmd_boom():
         return 42
 
     result = await rat_command.trigger()

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -79,7 +79,7 @@ async def test_reply(context_fx: Context):
                          ])
 @pytest.mark.asyncio
 async def test_from_message(bot_fx, channel, user, message, words, words_eol, prefixed):
-    ctx = await Context.from_message(bot_fx, channel, user, message)
+    ctx = await Context.from_message()
 
     if prefixed:
         assert ctx.prefixed

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -99,20 +99,20 @@ class TestPermissions(object):
 
     @pytest.mark.asyncio
     async def test_restricted_command_inferior(self, bot_fx, restricted_command_fx):
-        context = await Context.from_message(bot_fx, "#somechannel", "some_recruit", "!restricted")
-        await Commands.trigger(context)
+        context = await Context.from_message()
+        await Commands.trigger()
         assert not restricted_command_fx.was_called_once
 
     @pytest.mark.asyncio
     async def test_restricted_command_exact(self, bot_fx, restricted_command_fx):
-        context = await Context.from_message(bot_fx, "#somechannel", "some_ov", "!restricted")
-        await Commands.trigger(context)
+        context = await Context.from_message()
+        await Commands.trigger()
         assert restricted_command_fx.was_called_once
 
     @pytest.mark.asyncio
     async def test_restricted_command_superior(self, bot_fx, restricted_command_fx):
-        context = await Context.from_message(bot_fx, "#somechannel", "some_ov", "!restricted")
-        await Commands.trigger(context)
+        context = await Context.from_message()
+        await Commands.trigger()
         assert restricted_command_fx.was_called_once
 
     def test_hash(self):
@@ -126,7 +126,7 @@ class TestPermissions(object):
     async def test_require_channel_valid(self, bot_fx, context_channel_fx):
         """Verifies @require_channel does not stop commands invoked in a channel"""
 
-        @require_channel(message="https://www.youtube.com/watch?v=gvdf5n-zI14")
+        @require_channel(_message="https://www.youtube.com/watch?v=gvdf5n-zI14")
         async def potato(context: Context):
             return "hi there!"
 
@@ -183,7 +183,7 @@ class TestPermissions(object):
             in a channel context
         """
 
-        @require_channel(message=message)
+        @require_channel(_message=message)
         async def protected(context: Context):
             """protected function"""
             return "hot potato!"
@@ -199,7 +199,7 @@ class TestPermissions(object):
             in a pm context
         """
 
-        @require_channel(message=message)
+        @require_channel(_message=message)
         async def protected(context: Context):
             """protected function"""
             return "hot potato!"

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -22,6 +22,8 @@ import Modules.rat_command as Commands
 from Modules import permissions, context
 from Modules.permissions import require_permission, require_channel, require_dm, Permission
 
+pytestsmark = pytest.mark.permissions
+
 
 @pytest.fixture
 def Setup_fx(bot_fx):
@@ -37,278 +39,306 @@ def restricted_command_fx(async_callable_fx, Setup_fx):
     return async_callable_fx
 
 
-@pytest.mark.permissions
-@pytest.mark.usefixtures("Setup_fx")
-class TestPermissions(object):
+...
 
-    def test_permission_greater(self):
-        """
-        Tests if Permission_a > Permission_b functions correctly.
-        :return:
-        """
-        assert permissions.RAT > permissions.RECRUIT
-        assert permissions.ADMIN > permissions.RAT
-        assert not permissions.RAT > permissions.TECHRAT
 
-    def test_permission_lesser(self):
-        """
-        Tests if Permission_a < Permission_b correctly.
-        :return:
-        """
-        assert permissions.RECRUIT < permissions.RAT
-        assert permissions.RAT < permissions.TECHRAT
-        assert permissions.OVERSEER < permissions.TECHRAT
+def test_permission_greater():
+    """
+    Tests if Permission_a > Permission_b functions correctly.
+    :return:
+    """
+    assert permissions.RAT > permissions.RECRUIT
+    assert permissions.ADMIN > permissions.RAT
+    assert not permissions.RAT > permissions.TECHRAT
 
-    def test_permission_le(self):
-        """
-        Tests if Permission_a <= Permission_b correctly.
-        :return:
-        """
-        assert permissions.ADMIN <= permissions.ADMIN
-        assert not permissions.ADMIN <= permissions.RAT
-        assert permissions.OVERSEER <= permissions.ADMIN
-        assert not permissions.ADMIN <= permissions.OVERSEER
 
-    def test_permission_ge(self):
-        """
-        Tests if Permission_a <= Permission_b correctly.
-        :return:
-        """
-        assert permissions.ADMIN >= permissions.ADMIN
-        assert permissions.ADMIN >= permissions.RAT
-        assert not permissions.RAT >= permissions.OVERSEER
+def test_permission_lesser():
+    """
+    Tests if Permission_a < Permission_b correctly.
+    :return:
+    """
+    assert permissions.RECRUIT < permissions.RAT
+    assert permissions.RAT < permissions.TECHRAT
+    assert permissions.OVERSEER < permissions.TECHRAT
 
-    def test_permission_equal(self):
-        """
-        Verifies that Permission_a == Permission_b
-        :return:
-        """
-        assert permissions.RAT == permissions.RAT
-        assert permissions.TECHRAT == permissions.TECHRAT
-        assert permissions.ADMIN == permissions.ADMIN
 
-    def test_permission_not_equal(self):
-        """
-        Verifies that Permission_a != Permission_b
-        :return:
-        """
-        assert permissions.RAT != permissions.TECHRAT
-        assert permissions.RAT != permissions.OVERSEER
+def test_permission_le():
+    """
+    Tests if Permission_a <= Permission_b correctly.
+    :return:
+    """
+    assert permissions.ADMIN <= permissions.ADMIN
+    assert not permissions.ADMIN <= permissions.RAT
+    assert permissions.OVERSEER <= permissions.ADMIN
+    assert not permissions.ADMIN <= permissions.OVERSEER
 
-    @pytest.mark.asyncio
-    @pytest.mark.usefixtures('context_fx')
-    async def test_restricted_command_inferior(self, bot_fx, restricted_command_fx):
-        context.sender.set('some_recruit')
-        context.message.set(f"{Commands.prefix}restricted")
-        await context.from_message()
-        await Commands.trigger()
-        assert not restricted_command_fx.was_called_once
 
-    @pytest.mark.asyncio
-    @pytest.mark.usefixtures('context_fx')
-    async def test_restricted_command_exact(self, bot_fx, restricted_command_fx):
-        context.sender.set('some_ov')
-        context.message.set(f"{Commands.prefix}restricted")
-        await context.from_message()
-        await Commands.trigger()
-        assert restricted_command_fx.was_called_once
+def test_permission_ge():
+    """
+    Tests if Permission_a <= Permission_b correctly.
+    :return:
+    """
+    assert permissions.ADMIN >= permissions.ADMIN
+    assert permissions.ADMIN >= permissions.RAT
+    assert not permissions.RAT >= permissions.OVERSEER
 
-    @pytest.mark.asyncio
-    @pytest.mark.usefixtures('context_fx')
-    async def test_restricted_command_superior(self, bot_fx, restricted_command_fx):
-        context.sender.set('some_admin')
-        context.message.set(f"{Commands.prefix}restricted")
-        await context.from_message()
-        await Commands.trigger()
-        assert restricted_command_fx.was_called_once
 
-    def test_hash(self):
-        for perm1, perm2 in product(permissions._by_vhost.values(), permissions._by_vhost.values()):
-            if perm1 == perm2:
-                assert hash(perm1) == hash(perm2)
-            else:
-                assert hash(perm1) != hash(perm2)
+def test_permission_equal():
+    """
+    Verifies that Permission_a == Permission_b
+    :return:
+    """
+    assert permissions.RAT == permissions.RAT
+    assert permissions.TECHRAT == permissions.TECHRAT
+    assert permissions.ADMIN == permissions.ADMIN
 
-    @pytest.mark.asyncio
-    async def test_require_channel_valid(self, bot_fx):
-        """Verifies @require_channel does not stop commands invoked in a channel"""
-        context.channel.set("#unit_test")
-        context.target.set(("#unit_test"))
 
-        @require_channel(_message="https://www.youtube.com/watch?v=gvdf5n-zI14")
-        async def potato():
-            return "hi there!"
+def test_permission_not_equal():
+    """
+    Verifies that Permission_a != Permission_b
+    :return:
+    """
+    assert permissions.RAT != permissions.TECHRAT
+    assert permissions.RAT != permissions.OVERSEER
 
-        retn = await potato()
-        assert retn == "hi there!"
 
-    @pytest.mark.asyncio
-    async def test_require_channel_invalid(self, bot_fx):
-        """verifies require_channel stops commands invoked in PM contexts"""
-        context.target.set(bot_fx.nickname)
-        context.bot.set(bot_fx)
+@pytest.mark.asyncio
+@pytest.mark.usefixtures('context_fx')
+async def test_restricted_command_inferior(bot_fx, restricted_command_fx):
+    context.sender.set('some_recruit')
+    context.message.set(f"{Commands.prefix}restricted")
+    await context.from_message()
+    await Commands.trigger()
+    assert not restricted_command_fx.was_called_once
 
-        @require_channel
-        async def potato():
-            await context.reply("hi there!")
 
-        await potato()
+@pytest.mark.asyncio
+@pytest.mark.usefixtures('context_fx')
+async def test_restricted_command_exact(bot_fx, restricted_command_fx):
+    context.sender.set('some_ov')
+    context.message.set(f"{Commands.prefix}restricted")
+    await context.from_message()
+    await Commands.trigger()
+    assert restricted_command_fx.was_called_once
 
-        assert "This command must be invoked in a channel." == bot_fx.sent_messages[0]['message']
 
-    @pytest.mark.asyncio
-    async def test_require_channel_bare_channel(self, bot_fx):
-        """
-        Verifies @require_channel behaves properly as a plain invocation behaves as expected
-            in a channel context (not called with arguments)
-        """
-        context.target.set("#unit_test")
-        context.bot.set(bot_fx)
-        context.channel.set("#unit_test")
+@pytest.mark.asyncio
+@pytest.mark.usefixtures('context_fx')
+async def test_restricted_command_superior(bot_fx, restricted_command_fx):
+    context.sender.set('some_admin')
+    context.message.set(f"{Commands.prefix}restricted")
+    await context.from_message()
+    await Commands.trigger()
+    assert restricted_command_fx.was_called_once
 
-        @require_channel
-        async def protected():
-            """protected function"""
-            return "hot potato!"
 
-        data = await protected()
-        assert data == "hot potato!"
+def test_hash():
+    for perm1, perm2 in product(permissions._by_vhost.values(), permissions._by_vhost.values()):
+        if perm1 == perm2:
+            assert hash(perm1) == hash(perm2)
+        else:
+            assert hash(perm1) != hash(perm2)
 
-    @pytest.mark.asyncio
-    async def test_require_channel_bare_pm(self, bot_fx):
-        """
-        Verifies @require_channel behaves properly as a plain invocation behaves as expected
-            in a pm context
-        """
-        context.target.set(bot_fx.nickname)
-        context.channel.set(None)
-        context.bot.set(bot_fx)
 
-        @require_channel
-        async def protected():
-            """protected function"""
-            return "hot potato!"
+@pytest.mark.asyncio
+async def test_require_channel_valid(bot_fx):
+    """Verifies @require_channel does not stop commands invoked in a channel"""
+    context.channel.set("#unit_test")
+    context.target.set(("#unit_test"))
 
-        retn = await protected()
-        assert retn is None
-        assert "This command must be invoked in a channel." == bot_fx.sent_messages[0]['message']
+    @require_channel(_message="https://www.youtube.com/watch?v=gvdf5n-zI14")
+    async def potato():
+        return "hi there!"
 
-    @pytest.mark.parametrize("message", ["nope.", "https://www.youtube.com/watch?v=gvdf5n-zI14"])
-    @pytest.mark.asyncio
-    async def test_require_channel_call_channel(self, message: str):
-        """
-        Verifies @require_channel behaves properly as a plain invocation behaves as expected
-            in a channel context
-        """
-        context.target.set("#unit_test")
-        context.channel.set("#unit_test")
+    retn = await potato()
+    assert retn == "hi there!"
 
-        @require_channel(_message=message)
-        async def protected():
-            """protected function"""
-            return "hot potato!"
 
-        data = await protected()
-        assert data == "hot potato!"
+@pytest.mark.asyncio
+async def test_require_channel_invalid(bot_fx):
+    """verifies require_channel stops commands invoked in PM contexts"""
+    context.target.set(bot_fx.nickname)
+    context.bot.set(bot_fx)
+    context.channel.set(None)
 
-    @pytest.mark.parametrize("message", ["nope.", "https://www.youtube.com/watch?v=gvdf5n-zI14"])
-    @pytest.mark.asyncio
-    async def test_require_channel_call_pm(self, bot_fx, message: str):
-        """
-        Verifies @require_channel behaves properly as a plain invocation behaves as expected
-            in a pm context
-        """
-        context.target.set("some_rando")
-        context.bot.set(bot_fx)
+    @require_channel
+    async def potato():
+        await context.reply("hi there!")
 
-        @require_channel(_message=message)
-        async def protected():
-            """protected function"""
-            return "hot potato!"
+    await potato()
 
-        data = await protected()
-        assert data is None
-        assert message == bot_fx.sent_messages[0]['message']
+    assert bot_fx.sent_messages[0]['message'] == "This command must be invoked in a channel."
 
-    @pytest.mark.asyncio
-    async def test_require_dm_valid(self, context_pm_fx):
-        @require_dm()
-        async def potato():
-            return "hi there!"
 
-        retn = await context_pm_fx.run(potato())
-        assert retn == "hi there!"
+@pytest.mark.asyncio
+async def test_require_channel_bare_channel(bot_fx):
+    """
+    Verifies @require_channel behaves properly as a plain invocation behaves as expected
+        in a channel context (not called with arguments)
+    """
+    context.target.set("#unit_test")
+    context.bot.set(bot_fx)
+    context.channel.set("#unit_test")
 
-    @pytest.mark.asyncio
-    async def test_require_dm_invalid(self):
-        context.channel.set("#unit_test")
-        context.target.set("#unit_test")
+    @require_channel
+    async def protected():
+        """protected function"""
+        return "hot potato!"
 
-        @require_dm()
-        async def potato():
-            return "oh noes!"
+    data = await protected()
+    assert data == "hot potato!"
 
-        retn = await potato()
-        assert retn != "oh noes!"
 
-    @pytest.mark.parametrize("vhost",
-                             [{"unittest.fuelrats.com"}, {"potato.fuelrats.com"}, {"i.see.all"}])
-    def test_permission_registers_vhost(self, vhost, monkeypatch):
-        """Verifies a created Permission registers its vhosts"""
+@pytest.mark.tryfirst
+@pytest.mark.asyncio
+async def test_require_channel_bare_pm(bot_fx):
+    """
+    Verifies @require_channel behaves properly as a plain invocation behaves as expected
+        in a pm context
+    """
+    context.target.set(bot_fx.nickname)
+    context.channel.set(None)
+    context.bot.set(bot_fx)
 
-        # ensure _by_vhost is clean prior to running test
-        monkeypatch.setattr("Modules.permissions._by_vhost", {})
+    @require_channel
+    async def protected():
+        """protected function"""
+        return "hot potato!"
 
-        permission = Permission(1, vhost)
-        assert vhost == (set(permissions._by_vhost.keys()))
+    retn = await protected()
+    assert retn is None
+    assert "This command must be invoked in a channel." == bot_fx.sent_messages[0]['message']
 
-    @pytest.mark.parametrize("vhost_alpha", [{"techrat.fuelrats.com", "op.fuelrats.com"},
-                                             {"cannonfodder.fuelrats.com"}])
-    @pytest.mark.parametrize("vhost_beta", [
-        {"i.see.all"},
-        {"rats.fuelrats.com", "dispatch.fuelrats.com"}
-    ])
-    def test_permission_change_vhosts(self,
-                                      monkeypatch,
-                                      vhost_alpha: Set[str],
-                                      vhost_beta: Set[str]):
-        """Verifies the functionality of changing a Permission's vhosts property"""
-        # ensure _by_vhost is clean prior to running test
-        monkeypatch.setattr("Modules.permissions._by_vhost", {})
 
-        alpha = Permission(1, {"snafu.com"})
-        beta = Permission(2, {"FUBAR.com"})
+@pytest.mark.parametrize("message", ["nope.", "https://www.youtube.com/watch?v=gvdf5n-zI14"])
+@pytest.mark.asyncio
+async def test_require_channel_call_channel(message: str):
+    """
+    Verifies @require_channel behaves properly as a plain invocation behaves as expected
+        in a channel context
+    """
+    context.target.set("#unit_test")
+    context.channel.set("#unit_test")
 
-        alpha.vhosts = vhost_alpha
-        beta.vhosts = vhost_beta
-        # assert the new keys got into the _by_vhost dict
+    @require_channel(_message=message)
+    async def protected():
+        """protected function"""
+        return "hot potato!"
 
-        for vhost in vhost_alpha:
-            assert vhost in permissions._by_vhost
+    data = await protected()
+    assert data == "hot potato!"
 
-        for vhost in vhost_beta:
-            assert vhost in permissions._by_vhost
 
-        assert "snafu.com" not in permissions._by_vhost.keys()
-        assert "FUBAR.com" not in permissions._by_vhost.keys()
+@pytest.mark.parametrize("message", ["nope.", "https://www.youtube.com/watch?v=gvdf5n-zI14"])
+@pytest.mark.asyncio
+async def test_require_channel_call_pm(bot_fx, message: str):
+    """
+    Verifies @require_channel behaves properly as a plain invocation behaves as expected
+        in a pm context
+    """
+    context.target.set("some_rando")
+    context.channel.set(None)
+    context.bot.set(bot_fx)
 
-    @pytest.mark.parametrize("garbage", [None, dict(), 42, -1])
-    def test_permission_vhost_setter_garbage(self, garbage):
-        with pytest.raises(TypeError):
-            permissions.TECHRAT.vhosts = garbage
+    @require_channel(_message=message)
+    async def protected():
+        """protected function"""
+        return "hot potato!"
 
-    def test_permission_denied_message(self, monkeypatch):
-        # ensure _by_vhost is clean prior to running test
-        monkeypatch.setattr("Modules.permissions._by_vhost", {})
-        permission = Permission(0, {"test.fuelrats.com"}, "heck no.")
-        assert permission.denied_message == "heck no."
+    data = await protected()
+    assert data is None
+    assert message == bot_fx.sent_messages[0]['message']
 
-        permission.denied_message = "nope.avi"
-        assert permission.denied_message == "nope.avi"
 
-    @pytest.mark.parametrize("garbage", [None, dict(), 42, -1])
-    def test_denied_message_garbage(self, garbage, permission_fx: Permission):
-        # ensure _by_vhost is clean prior to running test
+@pytest.mark.asyncio
+async def test_require_dm_valid(bot_fx):
+    context.message.set("diiirect message!")
+    context.target.set(bot_fx.nickname)
+    context.channel.set(None)
 
-        with pytest.raises(TypeError):
-            permission_fx.denied_message = garbage
+    @require_dm()
+    async def potato():
+        return "hi there!"
+
+    retn = await potato()
+    assert retn == "hi there!"
+
+
+@pytest.mark.asyncio
+async def test_require_dm_invalid():
+    context.channel.set("#unit_test")
+    context.target.set("#unit_test")
+
+    @require_dm()
+    async def potato():
+        return "oh noes!"
+
+    retn = await potato()
+    assert retn != "oh noes!"
+
+
+@pytest.mark.parametrize("vhost",
+                         [{"unittest.fuelrats.com"}, {"potato.fuelrats.com"}, {"i.see.all"}])
+def test_permission_registers_vhost(vhost, monkeypatch):
+    """Verifies a created Permission registers its vhosts"""
+
+    # ensure _by_vhost is clean prior to running test
+    monkeypatch.setattr("Modules.permissions._by_vhost", {})
+
+    permission = Permission(1, vhost)
+    assert vhost == (set(permissions._by_vhost.keys()))
+
+
+@pytest.mark.parametrize("vhost_alpha", [{"techrat.fuelrats.com", "op.fuelrats.com"},
+                                         {"cannonfodder.fuelrats.com"}])
+@pytest.mark.parametrize("vhost_beta", [
+    {"i.see.all"},
+    {"rats.fuelrats.com", "dispatch.fuelrats.com"}
+])
+def test_permission_change_vhosts(
+        monkeypatch,
+        vhost_alpha: Set[str],
+        vhost_beta: Set[str]):
+    """Verifies the functionality of changing a Permission's vhosts property"""
+    # ensure _by_vhost is clean prior to running test
+    monkeypatch.setattr("Modules.permissions._by_vhost", {})
+
+    alpha = Permission(1, {"snafu.com"})
+    beta = Permission(2, {"FUBAR.com"})
+
+    alpha.vhosts = vhost_alpha
+    beta.vhosts = vhost_beta
+    # assert the new keys got into the _by_vhost dict
+
+    for vhost in vhost_alpha:
+        assert vhost in permissions._by_vhost
+
+    for vhost in vhost_beta:
+        assert vhost in permissions._by_vhost
+
+    assert "snafu.com" not in permissions._by_vhost.keys()
+    assert "FUBAR.com" not in permissions._by_vhost.keys()
+
+
+@pytest.mark.parametrize("garbage", [None, dict(), 42, -1])
+def test_permission_vhost_setter_garbage(garbage):
+    with pytest.raises(TypeError):
+        permissions.TECHRAT.vhosts = garbage
+
+
+def test_permission_denied_message(monkeypatch):
+    # ensure _by_vhost is clean prior to running test
+    monkeypatch.setattr("Modules.permissions._by_vhost", {})
+    permission = Permission(0, {"test.fuelrats.com"}, "heck no.")
+    assert permission.denied_message == "heck no."
+
+    permission.denied_message = "nope.avi"
+    assert permission.denied_message == "nope.avi"
+
+
+@pytest.mark.parametrize("garbage", [None, dict(), 42, -1])
+def test_denied_message_garbage(garbage, permission_fx: Permission):
+    # ensure _by_vhost is clean prior to running test
+
+    with pytest.raises(TypeError):
+        permission_fx.denied_message = garbage

--- a/tests/test_quotes.py
+++ b/tests/test_quotes.py
@@ -108,7 +108,7 @@ class TestQuotes(object):
         """
 
         quote = Quotation("foo")
-        quote.modify(context_fx, message="bar")
+        quote.modify(message="bar")
         assert "bar" == quote.message
         assert quote.created_at != quote.updated_at
         assert quote.author != quote.last_author

--- a/tests/test_rat_command.py
+++ b/tests/test_rat_command.py
@@ -37,8 +37,7 @@ class TestRatCommand(object):
         """
         Ensures that nothing happens and `trigger` exits quietly when no command can be found.
         """
-        await Commands.trigger(Context(None, None, "#unit_test", ['!unknowncommandsad hi!'],
-                                       ['!unknowncommandsad hi!', "hi!"]))
+        await Commands.trigger()
 
     @pytest.mark.parametrize("alias", ['potato', 'cannon', 'Fodder', 'fireball'])
     def test_double_command_registration(self, alias):
@@ -75,8 +74,8 @@ class TestRatCommand(object):
             # print(f"bot={bot}\tchannel={channel}\tsender={sender}")
             return context.bot, context.channel, context.user.nickname
 
-        ctx = await Context.from_message(bot_fx, "#unittest", "unit_test", trigger_alias)
-        retn = await Commands.trigger(ctx)
+        ctx = await Context.from_message()
+        retn = await Commands.trigger()
         out_bot, out_channel, out_sender = retn
 
         assert 'unit_test' == out_sender
@@ -141,5 +140,5 @@ class TestRatCommand(object):
             """asserts its arguments equal the outer scope"""
             assert words == context.words
 
-        ctx = await Context.from_message(bot_fx, "#unit_test", "unit_test", ftrigger)
-        await Commands.trigger(ctx)
+        ctx = await Context.from_message()
+        await Commands.trigger()

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -30,8 +30,8 @@ async def test_rule_matching(async_callable_fx: AsyncCallableMock,
     """Verifies that the rule decorator works as expected."""
     rule(regex, case_sensitive=case_sensitive,
          full_message=full_message)(async_callable_fx)
-    ctx = await Context.from_message(bot_fx, "#mordor", "unit_test", message)
-    await trigger(ctx)
+    ctx = await Context.from_message()
+    await trigger()
     # await trigger(message, "unit_test", "#mordor")
     assert async_callable_fx.was_called_once
 
@@ -49,8 +49,8 @@ async def test_rule_not_matching(async_callable_fx: AsyncCallableMock, regex: st
     rule(regex, case_sensitive=case_sensitive,
          full_message=full_message)(async_callable_fx)
     # await trigger(message, "unit_test", "theOneWithTheHills")
-    ctx = await Context.from_message(bot_fx, "#unit_test", "unit_test", message)
-    await trigger(ctx)
+    ctx = await Context.from_message()
+    await trigger()
     assert not async_callable_fx.was_called
 
 
@@ -60,9 +60,9 @@ async def test_rule_passes_match(async_callable_fx: AsyncCallableMock, bot_fx):
     Verifies that the rules get passed the match object correctly.
     """
     rule("her(lo)", pass_match=True)(async_callable_fx)
-    ctx = await Context.from_message(bot_fx, "#unit_test", "unit_test", "!herlo")
+    ctx = await Context.from_message()
 
-    await trigger(ctx)
+    await trigger()
 
     assert async_callable_fx.was_called_once
     assert async_callable_fx.was_called_with(InstanceOf(Context), InstanceOf(Match))
@@ -75,8 +75,8 @@ async def test_prefixless_rule_called(async_callable_fx: AsyncCallableMock, bot_
     Verifies that prefixless rules are considered when the prefix is not present.
     """
     rule("da_da(_da)?", prefixless=True)(async_callable_fx)
-    ctx = await Context.from_message(bot_fx, "#unit_test", "unit_test", "da_da")
-    await trigger(ctx)
+    ctx = await Context.from_message()
+    await trigger()
 
     assert async_callable_fx.was_called_once
     assert async_callable_fx.was_called_with(InstanceOf(Context))
@@ -94,8 +94,8 @@ async def test_prefixless_rule_not_called(regex: str, message: str,
     """
     rule(regex, prefixless=True)(async_callable_fx)
 
-    ctx = await Context.from_message(bot_fx, "#unit_test", "unit_test", message)
-    await trigger(ctx)
+    ctx = await Context.from_message()
+    await trigger()
 
     assert not async_callable_fx.was_called
 
@@ -158,9 +158,9 @@ async def test_rule_after(bot_fx):
     rule1 = rule("gaah")(async_callable_1)
     rule2 = rule("(g|b)aah", after=rule1)(async_callable_2)
 
-    ctx = await Context.from_message(bot_fx, "#channel", "unit_test", "!gaah")
+    ctx = await Context.from_message()
 
-    await trigger(ctx)
+    await trigger()
 
     assert async_callable_1.was_called_once
     assert not async_callable_2.was_called

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -101,7 +101,7 @@ async def test_user_from_whois_existing_user(bot_fx):
     verifies building a User from a full IRC reply when said user exists
     """
 
-    my_user = await User.from_pydle(bot_fx, "some_recruit")
+    my_user = User.from_pydle(bot_fx, "some_recruit")
 
     data = bot_fx.users['some_recruit']
 
@@ -123,7 +123,7 @@ async def test_user_from_whois_miss(monkeypatch, bot_fx):
     # patch in the exception raiser
     monkeypatch.setattr("tests.mock_bot.MockBot.whois", mock_whois)
 
-    ret = await User.from_pydle(bot_fx, "snafu")
+    ret = User.from_pydle(bot_fx, "snafu")
     assert ret is None
 
 
@@ -156,7 +156,7 @@ async def test_user_eq(data: dict, monkeypatch, bot_fx):
 
     monkeypatch.setattr(bot_fx, 'users', {data['nickname'].casefold(): data})
 
-    user_alpha = await User.from_pydle(bot_fx, data['nickname'])
+    user_alpha = User.from_pydle(bot_fx, data['nickname'])
     user_beta = User(**data)
 
     assert user_alpha == user_beta


### PR DESCRIPTION
This PR removes the `Modules.Context` dataclass in its entirety, it is nolonger necessary.

Rationale
---------------------------
Our present `Context` object is designed to store information relevant to `MechaClient.on_message()` Invocations, which it does in an acceptable fashion. It stores the bot's instance, the words of the message, and the sender as a `User` object. However, it is **horribly inflexible**.

For instance, if we want to expand the `Context` class to work for other event types, or store other data in the execution context it would require making global changes. Further, it is inefficient passing around a Context object into every routine involved in the handling of the event. Especially since only a small portion of the functions in the callchain actually /do/ anything with the Context object. Those that do generally don't use more than one or possibly two attributes in the Context object. 

Thus, passing around a `Context` object is bad for memory-management as it requires passing a useless object around, it increases cognative complexity (unused argument) and is inflexible (it is purpose-built with only one of many events in mind). **We would be better served with a more flexible solution**

Proposal
--------------------

Therefore, I propose introducing `ContextVar`s.
These were introduced in python 3.7, and provide async-safe thread-local storage. You can read up on them [here](https://www.python.org/dev/peps/pep-0567/) and [here](https://docs.python.org/3/library/contextvars.html)

In essence, `ContextVar`s provide us with the means of defining our context-sensitive variables in one place that can be imported where needed. This has the benefit of not needing to pass around the objects unnecessarily, as the functions only need to import what they need.

 Further, these objects are fully compatible with the asyncio event loop, and provides builtin isolation between asynchronous tasks. This means the bot can continue handing multiple concurrent irc messages without these variables becoming corrupted by one another

Finally, we can define new `ContextVar`s without needing to write additional tests, nor needing to change existing code except for the bits that will make use of the added var. This makes the approach far more expandable and easier to change should our future needs demand.


Implementation
------------------------

file `Modules.context` has been moved to `Modules.context._context`
- this was done so I could turn `Modules.context` into a package, to simply the public interface
`Context.from_message` has been moved to the module-scope
- this function has also been adapted to make use of the new `ContextVar`s
class `Modules.context.Context` has been removed, it is not necessary
Several new Context Variables have been introduced, they are defined in file `Modules.context._context` and exposed as part of the public interface `Modules.context`. See below.
## the new vars
`target`:`str` the target of a message
`channel`:`str` the target of a message, if it was a channel
`user`:`User` the User that invoked the message
`words`:`List[str]` the list of words for a `on_message` invocation
`words_eol`:`List[str]` list of words to eol
`prefixed`:`bool` whether or not a `on_message` invocation possesses the command prefix.
`message`:`str` the raw message of a `on_message` invocation
`bot`:`Mechaclient` the `MechaClient` instance.
`sender` :`str` the raw sender of a message.


Notes
------------------
This PR requires python 3.7 to work, so this Pr also has the side effect of raising the version bar. There is another Pr in the work that also makes use of 3.7 features so this isn't a problem.


