### PR TITLE
Add the 'utils' directory to coverage reports

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,7 @@
 
 [run]
 branch = False
-source = Modules,ratlib,database
+source = Modules,ratlib,database,utils
 
 [report]
 exclude_lines =

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,7 @@
 
 [run]
 branch = False
-source = Modules,ratlib,database,utils
+source = Modules,database,utils
 
 [report]
 exclude_lines =


### PR DESCRIPTION
The `utils` directory was never added to our code coverage, which was causing a warning to appear during coverage testing. This simple fix adds `utils` into `.coveragerc`.

Note that `utils/ratlib.py` currently has a coverage of 91%, so this may change may drop overall coverage slightly.