### PR TITLE
Adjust sanitize to filter tabs and IRC control codes

### DIFF
--- a/tests/test_ratlib.py
+++ b/tests/test_ratlib.py
@@ -13,23 +13,40 @@ nickname_test_list = [
     ('Shatt[PC|afk]', 'Shatt')
 ]
 
-sanitize_test_list = [
-    ('4Red Text,12,', 'Red Text,12,'),
-    ('4,4Red Text on Red B@ckground', 'Red Text on Red B@ckground'),
-    ('10,10Lorem ipsum dolor sit amet', 'Lorem ipsum dolor sit amet'),
-    ('Bold Text;;;', 'Bold Text'),
-    ('Bold Italic Text', 'Bold Italic Text'),
-    ('4Bold Red Text', 'Bold Red Text'),
+SANITIZE_TEST_LIST = [
     ('Um die Rat zu deiner Freundesliste hinzuzufügen drücke',
      'Um die Rat zu deiner Freundesliste hinzuzufügen drücke'),
     ('которые отдают топливо, нажмите здесь: http://t.fuelr.at/kgbfoamru',
      'которые отдают топливо, нажмите здесь: http://t.fuelr.at/kgbfoamru'),
-    ('a;A;B;b;C;c;123', 'aABbCc123'),
     ('!inject 99 5:30 o2 remaining', '!inject 99 5:30 o2 remaining'),
-    (',Banana', 'Banana'),
-    ('137Banana', 'Banana'),
+    ('\tTab\tbing\tton', 'Tabbington'),
+    ('Strikethrough', 'Strikethrough'),
+    ('Underline', 'Underline'),
+    ('Monospace', 'Monospace'),
+    ('Reverse', 'Reverse'),
+    ('Reset', 'Reset'),
+    ('Bold Text', 'Bold Text'),
+    ('Bold Italic Text', 'Bold Italic Text'),
+    ('4Bold Red Text', 'Bold Red Text'),
+    (',Banana', ',Banana'),
+    ('137Banana', '7Banana'),
+    ('4Red Text,12,', 'Red Text,12,'),
+    ('4,4Red Text on Red B@ckground', 'Red Text on Red B@ckground'),
+    ('10,10Lorem ipsum dolor sit amet', 'Lorem ipsum dolor sit amet'),
+    ('04Red 03Green 02Blue', 'Red Green Blue'),
+    ('13,Banana', ',Banana'),
+    ('13,01Banana', 'Banana'),
     (',Banana', ',Banana'),
-    ('13,15Banana', 'Banana')
+    ('13,15Banana', 'Banana'),
+    (',15Banana', ',15Banana'),
+    ('Bold Italic Underline', 'Bold Italic Underline'),
+    ('HexColor', 'HexColor'),
+    ('fFa5DCBanana', 'Banana'),
+    ('ffffff,000000Banana', 'Banana'),
+    ('123456,Banana', ',Banana'),
+    ('FF0000Red 00fF00Green 0000ffBlue', 'Red Green Blue'),
+    ('no 4ite56AdcBms2, fo\tx onlyFF66AA, final des\tt555555ination',
+     'no items, fox only, final destination')
 ]
 
 
@@ -41,7 +58,7 @@ def test_strip_name(nickname, expected):
     assert utils.ratlib.strip_name(nickname) == expected
 
 
-@pytest.mark.parametrize("input_message, expected_message", sanitize_test_list)
+@pytest.mark.parametrize("input_message, expected_message", SANITIZE_TEST_LIST)
 def test_sanitize(input_message, expected_message):
     """
     Verifies sanitize routine is properly removing string elements.

--- a/utils/ratlib.py
+++ b/utils/ratlib.py
@@ -16,9 +16,7 @@ from enum import Enum
 from uuid import UUID
 from typing import Optional
 
-MIRC_CONTROL_CODES = ["\x0F", "\x16", "\x1D", "\x1F", "\x02",
-                      "\x03([1-9][0-6]?)?,?([1-9][0-6]?)?"]
-STRIPPED_CHARS = ';'
+STRIPPED_CHARS = '\t'
 
 
 class Platforms(Enum):
@@ -121,11 +119,14 @@ def sanitize(message: str) -> str:
     """
     sanitized_string = message
 
-    # Remove mIRC codes
-    for code in MIRC_CONTROL_CODES:
-        sanitized_string = re.sub(code, '', sanitized_string, re.UNICODE)
+    # Remove IRC control codes for color, bold, underline, etc.
+    control_code_regex = re.compile(r"([\x02\x1D\x1F\x1E\x11\x16\x0F]|"
+                                    r"(\x03([0-9]{1,2}(,[0-9]{1,2})?)?)|"
+                                    r"(\x04([0-9a-fA-F]{6}(,[0-9a-fA-F]{6})?)?))"
+                                    )
+    sanitized_string = control_code_regex.sub('', sanitized_string)
 
-    # Remove tabs and semi-colons
+    # Remove stripped characters. (e.g. Tabs)
     for character in sanitized_string:
         if character in STRIPPED_CHARS:
             sanitized_string = sanitized_string.replace(character, '')


### PR DESCRIPTION
Fixes SPARK-73.

This rewrites the regular expression that filters out IRC control codes, and now includes every control code I could find. Including bold, italic, underline, strikethrough, monospace, color, hex color, reverse color, and reset.

This also removes the unnecessary stripping of semicolons from IRC messages, and it will now filter tabs from messages.