### PR TITLE
Fix Pytest deprecation warning

### DIFF
--- a/tests/test_rescue.py
+++ b/tests/test_rescue.py
@@ -339,7 +339,7 @@ async def test_add_rats_bad_id(rat_no_id_fx, rescue_sop_fx):
     """
     Verifies attempting to add a rat that does not have a API id fails as expected
     """
-    with pytest.raises(ValueError, message="Assigned rat does not have a known API ID"):
+    with pytest.raises(ValueError, match="Assigned rat does not have a known API ID"):
         await rescue_sop_fx.add_rat(rat=rat_no_id_fx)
         assert rat_no_id_fx not in rescue_sop_fx.rats
 


### PR DESCRIPTION
Since updating to pytest 4.1.0, they have deprecated the `message` parameter of `pytest.raises`. And for good reason. Like a lot of developers, we were using the parameter incorrectly.

The `message` parameter was meant to take a string that Pytest would output to the console if the exception was not raised. It does **not** check the exception message against the string given. That is the responsibility of the `match` parameter, which I have changed our test to use.