### PR TITLE
Speed up Galaxy's testing on Windows

### DIFF
--- a/tests/galaxy/conftest.py
+++ b/tests/galaxy/conftest.py
@@ -22,7 +22,7 @@ def mock_system_api_server_fx():
     """
     # pylint: disable=line-too-long
 
-    with HTTPServer() as httpserver:
+    with HTTPServer('127.0.0.1', '4000') as httpserver:
         # System Data
         # - Fuelum
         httpserver.expect_request("/api/systems", query_string=b"filter%5Bname:eq%5D=FUELUM").respond_with_data(


### PR DESCRIPTION
According to [the documentation of werkzeug](http://werkzeug.pocoo.org/docs/0.14/serving/#troubleshooting), some later \*nix and Windows machines struggle to use `localhost` as a hostname, because they attempt to use IPv6 first, fail, then fall back on IPv4.

This caused the test suite of `Galaxy` to run upwards of 20 seconds on Windows platforms. To fix this issue, I've adjusted the mock server to use an IPv4 address explicitly, thus overcoming the issue of IPv6 resolution.