### PR TITLE
Fixes doctest misconfiguration

### DIFF
--- a/database/database_manager.py
+++ b/database/database_manager.py
@@ -6,11 +6,13 @@ All rights reserved.
 Licensed under the BSD 3-Clause License.
 See LICENSE.md
 """
-from config import config
-from psycopg2 import sql, pool
-from typing import Union, Tuple, List, Dict
 import logging
+from typing import Union, Tuple, List, Dict
+
 import psycopg2
+from psycopg2 import sql
+
+from config import config
 
 log = logging.getLogger(f"mecha.{__name__}")
 
@@ -44,9 +46,10 @@ class DatabaseManager(object):
         DO NOT USE STRING CONCATENATION OR APPEND VALUES.  THIS IS BAD PRACTICE, AND AN INJECTION
         RISK!
 
-        >>> query = sql.SQL("SELECT FROM public.table WHERE" \
-        ...                 "table.name=%s AND table.lang=%s AND table.something=%s")
-        ... DatabaseManager.query(query, ('tuple','of','values'))
+        >>> query = sql.SQL(
+        ... "SELECT FROM public.table WHERE table.name=%s AND table.lang=%s AND table.something=%s")
+
+        >>> dbm.query(query, ('tuple','of','values'))# doctest: +SKIP
 
     """
 

--- a/database/database_manager.py
+++ b/database/database_manager.py
@@ -24,7 +24,7 @@ class DatabaseManager(object):
 
         Usage:
         >>> DatabaseManager(dbhost='DatabaseServer.org',
-        ...                 dport=5432,
+        ...                 dbport=5432,
         ...                 dbname='DatabaseName',
         ...                 dbuser='DatabaseUserName',
         ...                 dbpassword='UserPassword')

--- a/database/database_manager.py
+++ b/database/database_manager.py
@@ -27,7 +27,7 @@ class DatabaseManager(object):
         ...                 dbport=5432,
         ...                 dbname='DatabaseName',
         ...                 dbuser='DatabaseUserName',
-        ...                 dbpassword='UserPassword')
+        ...                 dbpassword='UserPassword') # doctest: +SKIP
 
         All arguments are optional.  If omitted, config values will be pulled from config file.
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -21,4 +21,4 @@ markers =
     database_manager: database tests
     galaxy: marks a test as a galaxy test
 
-addopts = tests
+addopts = --doctest-modules

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,10 @@ import sys
 from uuid import uuid4, UUID
 
 import psycopg2
+import psycopg2.pool
 import pytest
+
+# from psycopg2.pool import SimpleConnectionPool
 
 from Modules.rat_cache import RatCache
 


### PR DESCRIPTION
fixes reconfiguration introduced in #73 that caused doctests for modules not to execute.

An unfortunate side-effect of specifying the starting directory for test discovery, pointing it at a directory outside our Module space, is that doctests are not discovered in the module space. The lack of discovery, therefore, means they will not be run.

Edit: its worth noting the original impetus for #73 is resolved by us now using the normal pydle distribution.