### PR TITLE
Add CODEOWNERS configuration file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 
 
 # global rule
-@theunkn0wn1
+* @theunkn0wn1
 
 # documentation directory
 /docs/ @shatteredbeam

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,32 @@
+#https://help.github.com/articles/about-code-owners/
+
+
+# global rule
+@theunkn0wn1
+
+# documentation directory
+/docs/ @shatteredbeam
+
+# database module
+/database/ @shatteredbeam
+
+# facts module
+/Modules/fact_manager.py @shatteredbeam
+
+# commands module
+/commands/ @theunkn0wn1
+
+# galaxy module
+/Modules/galaxy/ @Eearslya
+
+# rules module
+/Modules/rules.py @MHajoha
+
+# #####
+various CI configuration files.
+*.yml @theunkn0wn1
+*.ini @theunkn0wn1
+*.cfg @theunkn0wn1
+
+/.circleci/ @theunkn0wn1
+.coveragerc @theunkn0wn1


### PR DESCRIPTION
This PR adds a `CODEOWNERS` configuration file to the project.

This file defines who is automatically requested / required to approve a pull request based on the files that have been changed.

I have assigned codeowners based on which parts of the project each member is assigned to, hopefully everyone finds the configuration acceptable. If not, feel free to yell at me.

anything in `/docs/`, as well as `/database/` and `Modules/fact_manager.py` have been assigned to @shatteredbeam 

Anything in `/Galaxy/` is assigned to @Eearslya 

Rules are assigned to @MHajoha , and the API module will be as well once merged.

I have assigned myself to anything not otherwise claimed, as well as explicitly claiming the various CI configuration files.

In theory this is just a formalization, rather than a procedural change