### PR TITLE
Add find_nearest_landmark method to Galaxy

### DIFF
--- a/Modules/galaxy/galaxy.py
+++ b/Modules/galaxy/galaxy.py
@@ -108,7 +108,7 @@ class Galaxy:
 
         closest_system = None
         closest_distance = -1
-        for _, landmark in self.LANDMARK_SYSTEMS.items():
+        for landmark in self.LANDMARK_SYSTEMS.values():
             distance = system.distance(landmark)
             if closest_distance == -1 or distance < closest_distance:
                 closest_distance = round(distance, 2)

--- a/tests/galaxy/conftest.py
+++ b/tests/galaxy/conftest.py
@@ -58,6 +58,10 @@ def mock_system_api_server_fx():
         httpserver.expect_request("/api/stars", query_string=b"filter%5BsystemId64:eq%5D=5031721931482&filter%5BisMainStar:eq%5D=1").respond_with_data(
             """{"data":[{"id":"3206960","attributes":{"id64":36033828740895450,"name":"Fuelum","subType":"K (Yellow-Orange) Star","isMainStar":true}}],"meta":{"results":{"available":1}}}"""
         )
+        # - Angrbonii
+        httpserver.expect_request("/api/stars", query_string=b"filter%5BsystemId64:eq%5D=40557912804216&filter%5BisMainStar:eq%5D=1").respond_with_data(
+            """{"data":[{"id":"377822","attributes":{"id64":72098151950732160,"name":"Angrbonii A","subType":"L (Brown dwarf) Star","isMainStar":true}}],"meta":{"results":{"available":1}}}"""
+        )
         # - Fallthrough for failed searches
         httpserver.expect_request("/api/stars").respond_with_data(
             """{"data":[],"included":[],"meta":{"results":{"available":0}}}"""

--- a/tests/galaxy/test_galaxy.py
+++ b/tests/galaxy/test_galaxy.py
@@ -19,12 +19,12 @@ async def test_find_system_by_name(galaxy_fx):
     """
     Test that we can find a system by name and get the proper information.
     """
-    system = await galaxy_fx.find_system_by_name("Fuelum")
-    assert system.position.x == 52.0
-    assert system.position.y == -52.65625
-    assert system.position.z == 49.8125
-    assert system.name == "FUELUM"
-    assert system.spectral_class == "K"
+    system = await galaxy_fx.find_system_by_name("Angrbonii")
+    assert system.position.x == 61.65625
+    assert system.position.y == -42.4375
+    assert system.position.z == 53.59375
+    assert system.name == "ANGRBONII"
+    assert system.spectral_class == "L"
 
 
 @pytest.mark.asyncio
@@ -34,6 +34,40 @@ async def test_find_system_by_invalid_name(galaxy_fx):
     """
     invalid = await galaxy_fx.find_system_by_name("Fualun")
     assert invalid is None
+
+
+@pytest.mark.asyncio
+async def test_find_nearest_landmark(galaxy_fx):
+    """
+    Test that we can find the nearest landmark from a provided system.
+    """
+    system = await galaxy_fx.find_system_by_name('Angrbonii')
+    nearest = await galaxy_fx.find_nearest_landmark(system)
+    assert nearest[0].name == 'FUELUM'
+    assert nearest[1] == 14.56
+
+
+@pytest.mark.asyncio
+async def test_find_nearest_landmark_self(galaxy_fx):
+    """
+    Test that a trying to find the nearest landmark from a landmark system returns itself.
+    """
+    system = await galaxy_fx.find_system_by_name('Fuelum')
+    nearest = await galaxy_fx.find_nearest_landmark(system)
+    assert nearest[0].name == 'FUELUM'
+    assert nearest[1] == 0
+
+
+@pytest.mark.asyncio
+async def test_find_nearest_landmark_invalid(galaxy_fx, monkeypatch):
+    """
+    Test that find_nearest_landmark will raise in the unlikely event it can't find
+    a landmark.
+    """
+    system = await galaxy_fx.find_system_by_name('Angrbonii')
+    monkeypatch.setattr(galaxy_fx, 'LANDMARK_SYSTEMS', {})
+    with pytest.raises(RuntimeError):
+        await galaxy_fx.find_nearest_landmark(system)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
For SPARK-95.

This adds a new method to `Galaxy`, `find_nearest_landmark`. Given an existing `StarSystem` object, it will find the nearest system out of a hardcoded list of "landmark" star systems. This will help to provide location context for things like rescue announcements (the `(158ly from Sol)` part, specifically.)