### PR TITLE
Add platform to Rescue's constructor

### DIFF
--- a/Modules/rat_rescue.py
+++ b/Modules/rat_rescue.py
@@ -51,8 +51,6 @@ class Rescue(object):
         creates a unique rescue
 
         Args:
-
-            platform ():
             code_red (bool): is the client on emergency oxygen
             status (Status): status attribute for the rescue
             board (RatBoard): RatBoard instance this rescue is attached to, if any.

--- a/Modules/rat_rescue.py
+++ b/Modules/rat_rescue.py
@@ -36,19 +36,29 @@ class Rescue(object):
     A unique rescue
     """
 
-    def __init__(self, uuid: UUID = None, client: Optional[str] = None,
-                 system: Optional[str] = None, irc_nickname: Optional[str] = None,
-                 board: 'RatBoard' = None, created_at: Optional[datetime] = None,
+    def __init__(self,
+                 uuid: UUID = None,
+                 client: Optional[str] = None,
+                 system: Optional[str] = None,
+                 irc_nickname: Optional[str] = None,
+                 board: 'RatBoard' = None,
+                 created_at: Optional[datetime] = None,
                  updated_at: Optional[datetime] = None,
-                 unidentified_rats: Optional[List[str]] = None, active: bool = True,
-                 quotes: Optional[List[Quotation]] = None, epic: List[Epic] = None,
-                 title: Optional[str] = None, first_limpet: Optional[UUID] = None,
+                 unidentified_rats: Optional[List[str]] = None,
+                 active: bool = True,
+                 quotes: Optional[List[Quotation]] = None,
+                 epic: List[Epic] = None,
+                 title: Optional[str] = None,
+                 first_limpet: Optional[UUID] = None,
                  board_index: Optional[int] = None,
-                 mark_for_deletion: MarkForDeletion = MarkForDeletion(), lang_id: str = "EN",
-                 rats: List[Rat] = None, status: Status = Status.OPEN, code_red=False,
+                 mark_for_deletion: MarkForDeletion = MarkForDeletion(),
+                 lang_id: str = "EN",
+                 rats: List[Rat] = None,
+                 status: Status = Status.OPEN,
+                 code_red=False,
                  platform: Platforms = None):
         """
-        creates a unique rescue
+        creates a rescue
 
         Args:
             code_red (bool): is the client on emergency oxygen

--- a/Modules/rat_rescue.py
+++ b/Modules/rat_rescue.py
@@ -36,30 +36,23 @@ class Rescue(object):
     A unique rescue
     """
 
-    def __init__(self, uuid: UUID = None,
-                 client: Optional[str] = None,
-                 system: Optional[str] = None,
-                 irc_nickname: Optional[str] = None,
-                 board: 'RatBoard' = None,
-                 created_at: Optional[datetime] = None,
+    def __init__(self, uuid: UUID = None, client: Optional[str] = None,
+                 system: Optional[str] = None, irc_nickname: Optional[str] = None,
+                 board: 'RatBoard' = None, created_at: Optional[datetime] = None,
                  updated_at: Optional[datetime] = None,
-                 unidentified_rats: Optional[List[str]] = None,
-                 active: bool = True,
-                 quotes: Optional[List[Quotation]] = None,
-                 epic: List[Epic] = None,
-                 title: Optional[str] = None,
-                 first_limpet: Optional[UUID] = None,
+                 unidentified_rats: Optional[List[str]] = None, active: bool = True,
+                 quotes: Optional[List[Quotation]] = None, epic: List[Epic] = None,
+                 title: Optional[str] = None, first_limpet: Optional[UUID] = None,
                  board_index: Optional[int] = None,
-                 mark_for_deletion: MarkForDeletion = MarkForDeletion(),
-                 lang_id: str = "EN",
-                 rats: List[Rat] = None,
-                 status: Status = Status.OPEN,
-                 code_red=False):
+                 mark_for_deletion: MarkForDeletion = MarkForDeletion(), lang_id: str = "EN",
+                 rats: List[Rat] = None, status: Status = Status.OPEN, code_red=False,
+                 platform: Platforms = None):
         """
         creates a unique rescue
 
         Args:
 
+            platform ():
             code_red (bool): is the client on emergency oxygen
             status (Status): status attribute for the rescue
             board (RatBoard): RatBoard instance this rescue is attached to, if any.
@@ -85,8 +78,9 @@ class Rescue(object):
             irc_nickname (str): clients IRC nickname, may deffer from their
                 commander name.
             rats (list): identified (Rat)s assigned to rescue.
+            platform(Platforms): Platform for rescue
         """
-        self._platform: Platforms = None
+        self._platform: Platforms = platform
         self.rat_board: 'RatBoard' = board
         self._rats = rats if rats else []
         self._createdAt: datetime = created_at if created_at else datetime.utcnow()


### PR DESCRIPTION
Adds `platform` to Rescue's constructor with a default value of `None`.

