### PR TITLE
Lint/adjust pylint

### DIFF
--- a/pylint.ini
+++ b/pylint.ini
@@ -138,7 +138,9 @@ disable=print-statement,
         deprecated-sys-function,
         exception-escape,
         comprehension-escape,
-        logging-fstring-interpolation
+        logging-fstring-interpolation,
+        too-many-arguments,
+        too-many-instance-attributes
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/pylint.ini
+++ b/pylint.ini
@@ -209,7 +209,7 @@ bad-names=foo,
           tata
 
 # Naming style matching correct class attribute names.
-class-attribute-naming-style=snake_case
+class-attribute-naming-style=any
 
 # Regular expression matching correct class attribute names. Overrides class-
 # attribute-naming-style.
@@ -460,7 +460,7 @@ dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
 ignored-argument-names=_.*|^ignored_|^unused_
 
 # Tells whether we should check for unused import in __init__ files.
-init-import=yes
+init-import=no
 
 # List of qualified module names which can have objects that can redefine
 # builtins.

--- a/pylint.ini
+++ b/pylint.ini
@@ -64,7 +64,6 @@ disable=print-statement,
         parameter-unpacking,
         unpacking-in-except,
         old-raise-syntax,
-        backtick,
         long-suffix,
         old-ne-operator,
         old-octal-literal,
@@ -210,7 +209,7 @@ bad-names=foo,
           tata
 
 # Naming style matching correct class attribute names.
-class-attribute-naming-style=any
+class-attribute-naming-style=snake_case
 
 # Regular expression matching correct class attribute names. Overrides class-
 # attribute-naming-style.
@@ -253,7 +252,7 @@ good-names=i,
 include-naming-hint=no
 
 # Naming style matching correct inline iteration names.
-inlinevar-naming-style=any
+inlinevar-naming-style=snake_case
 
 # Regular expression matching correct inline iteration names. Overrides
 # inlinevar-naming-style.
@@ -335,7 +334,7 @@ single-line-if-stmt=no
 
 # Format style used to check logging format string. `old` means using %
 # formatting, while `new` is for `{}` formatting.
-logging-format-style=old
+logging-format-style=new
 
 # Logging modules to check that the string format arguments are in logging
 # function parameter format.
@@ -449,7 +448,8 @@ allow-global-unused-variables=yes
 # List of strings which can identify a callback function by name. A callback
 # name must start or end with one of those strings.
 callbacks=cb_,
-          _cb
+          _cb,
+          _callback
 
 # A regular expression matching the name of dummy variables (i.e. expected to
 # not be used).
@@ -460,7 +460,7 @@ dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
 ignored-argument-names=_.*|^ignored_|^unused_
 
 # Tells whether we should check for unused import in __init__ files.
-init-import=no
+init-import=yes
 
 # List of qualified module names which can have objects that can redefine
 # builtins.
@@ -513,13 +513,13 @@ max-parents=7
 max-public-methods=20
 
 # Maximum number of return / yield for function / method body.
-max-returns=6
+max-returns=4
 
 # Maximum number of statements in function / method body.
 max-statements=50
 
 # Minimum number of public methods for a class (see R0903).
-min-public-methods=2
+min-public-methods=1
 
 
 [IMPORTS]
@@ -549,7 +549,7 @@ int-import-graph=
 
 # Force import order to recognize a module as part of the standard
 # compatibility libraries.
-known-standard-library=
+known-standard-library=dataclasses
 
 # Force import order to recognize a module as part of a third party library.
 known-third-party=enchant

--- a/src/packages/permissions/permissions.py
+++ b/src/packages/permissions/permissions.py
@@ -11,14 +11,24 @@ See LICENSE.md
 This module is built on top of the Pydle system.
 
 """
+
 import logging
 from functools import wraps
-from typing import Any, Union, Callable, List, Dict, Set
+from typing import Any, Union, Callable, Dict, Set
 
 from config import config
 from ..context import Context
 
 log = logging.getLogger(f"mecha.{__name__}")
+
+__all__ = [
+    "Permission",
+    "RECRUIT",
+    "RAT",
+    "OVERSEER",
+    "TECHRAT",
+    "ADMIN"
+]
 
 
 class Permission:
@@ -76,13 +86,13 @@ class Permission:
         - Items that are not in `vhosts` already are added to `_by_vhost`
 
         Args:
-            value (List[str]): list of vhosts
+            value (Set[str]): set of vhosts
 
         Returns:
             None
         """
         if not isinstance(value, set):
-            raise TypeError(f"expected list got {type(value)}")
+            raise TypeError(f"expected set got {type(value)}")
 
         # determine which items have been removed
         removed = self.vhosts - value


### PR DESCRIPTION
Adjust the pylint configuration file, hopefully its a tad more sane now.


Supressed warnings for number of arguments and number of instance attributes, I would rather judge these ones by hand as we have some large objects int he codebase...



Also tried to fix permissions up a bit, fixing a wording error and adding a `__all__` as a wildcard import is the cleanest solution here...