### PR TITLE
[SPARK-109] Add pylint-quotes to linting

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -28,7 +28,7 @@ limit-inference-results=100
 
 # List of plugins (as comma separated values of python modules names) to load,
 # usually to register additional checkers.
-load-plugins=
+load-plugins=pylint_quotes
 
 # Pickle collected data for later comparisons.
 persistent=yes
@@ -562,3 +562,11 @@ known-third-party=enchant
 # Exceptions that will emit a warning when being caught. Defaults to
 # "Exception".
 overgeneral-exceptions=Exception
+
+
+[QUOTES]
+
+# Settings for pylint-quotes to enforce the usage of double quotes for strings.
+string-quote=double
+triple-quote=double
+docstring-quote=double

--- a/Pipfile
+++ b/Pipfile
@@ -10,7 +10,6 @@ pure-sasl = "*"
 coloredlogs = "*"
 psycopg2 = "*"
 humanfriendly = "*"
-pylint-quotes = "*"
 
 [dev-packages]
 pytest = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,7 @@ pure-sasl = "*"
 coloredlogs = "*"
 psycopg2 = "*"
 humanfriendly = "*"
+pylint-quotes = "*"
 
 [dev-packages]
 pytest = "*"
@@ -19,6 +20,7 @@ pylint = "*"
 pytest-httpserver = "*"
 codecov = "*"
 pycodestyle = "*"
+pylint-quotes = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "bb1ce9e9c0fda63e3ee91853bc3a45451a75b53a7ebaff127b32e89bf64edf1c"
+            "sha256": "e54d7f61494c660089f83f101d8350f05db2df25b3555e47fe082995e9e0f7fe"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -43,13 +43,6 @@
             ],
             "index": "pypi",
             "version": "==3.5.4"
-        },
-        "astroid": {
-            "hashes": [
-                "sha256:6560e1e1749f68c64a4b5dee4e091fce798d2f0d84ebe638cf0e0585a343acf4",
-                "sha256:b65db1bbaac9f9f4d190199bb8680af6f6f84fd3769a5ea883df8a91fe68b4c4"
-            ],
-            "version": "==2.2.5"
         },
         "async-timeout": {
             "hashes": [
@@ -94,54 +87,6 @@
                 "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
             ],
             "version": "==2.8"
-        },
-        "isort": {
-            "hashes": [
-                "sha256:18c796c2cd35eb1a1d3f012a214a542790a1aed95e29768bdcb9f2197eccbd0b",
-                "sha256:96151fca2c6e736503981896495d344781b60d18bfda78dc11b290c6125ebdb6"
-            ],
-            "version": "==4.3.15"
-        },
-        "lazy-object-proxy": {
-            "hashes": [
-                "sha256:0ce34342b419bd8f018e6666bfef729aec3edf62345a53b537a4dcc115746a33",
-                "sha256:1b668120716eb7ee21d8a38815e5eb3bb8211117d9a90b0f8e21722c0758cc39",
-                "sha256:209615b0fe4624d79e50220ce3310ca1a9445fd8e6d3572a896e7f9146bbf019",
-                "sha256:27bf62cb2b1a2068d443ff7097ee33393f8483b570b475db8ebf7e1cba64f088",
-                "sha256:27ea6fd1c02dcc78172a82fc37fcc0992a94e4cecf53cb6d73f11749825bd98b",
-                "sha256:2c1b21b44ac9beb0fc848d3993924147ba45c4ebc24be19825e57aabbe74a99e",
-                "sha256:2df72ab12046a3496a92476020a1a0abf78b2a7db9ff4dc2036b8dd980203ae6",
-                "sha256:320ffd3de9699d3892048baee45ebfbbf9388a7d65d832d7e580243ade426d2b",
-                "sha256:50e3b9a464d5d08cc5227413db0d1c4707b6172e4d4d915c1c70e4de0bbff1f5",
-                "sha256:5276db7ff62bb7b52f77f1f51ed58850e315154249aceb42e7f4c611f0f847ff",
-                "sha256:61a6cf00dcb1a7f0c773ed4acc509cb636af2d6337a08f362413c76b2b47a8dd",
-                "sha256:6ae6c4cb59f199d8827c5a07546b2ab7e85d262acaccaacd49b62f53f7c456f7",
-                "sha256:7661d401d60d8bf15bb5da39e4dd72f5d764c5aff5a86ef52a042506e3e970ff",
-                "sha256:7bd527f36a605c914efca5d3d014170b2cb184723e423d26b1fb2fd9108e264d",
-                "sha256:7cb54db3535c8686ea12e9535eb087d32421184eacc6939ef15ef50f83a5e7e2",
-                "sha256:7f3a2d740291f7f2c111d86a1c4851b70fb000a6c8883a59660d95ad57b9df35",
-                "sha256:81304b7d8e9c824d058087dcb89144842c8e0dea6d281c031f59f0acf66963d4",
-                "sha256:933947e8b4fbe617a51528b09851685138b49d511af0b6c0da2539115d6d4514",
-                "sha256:94223d7f060301b3a8c09c9b3bc3294b56b2188e7d8179c762a1cda72c979252",
-                "sha256:ab3ca49afcb47058393b0122428358d2fbe0408cf99f1b58b295cfeb4ed39109",
-                "sha256:bd6292f565ca46dee4e737ebcc20742e3b5be2b01556dafe169f6c65d088875f",
-                "sha256:cb924aa3e4a3fb644d0c463cad5bc2572649a6a3f68a7f8e4fbe44aaa6d77e4c",
-                "sha256:d0fc7a286feac9077ec52a927fc9fe8fe2fabab95426722be4c953c9a8bede92",
-                "sha256:ddc34786490a6e4ec0a855d401034cbd1242ef186c20d79d2166d6a4bd449577",
-                "sha256:e34b155e36fa9da7e1b7c738ed7767fc9491a62ec6af70fe9da4a057759edc2d",
-                "sha256:e5b9e8f6bda48460b7b143c3821b21b452cb3a835e6bbd5dd33aa0c8d3f5137d",
-                "sha256:e81ebf6c5ee9684be8f2c87563880f93eedd56dd2b6146d8a725b50b7e5adb0f",
-                "sha256:eb91be369f945f10d3a49f5f9be8b3d0b93a4c2be8f8a5b83b0571b8123e0a7a",
-                "sha256:f460d1ceb0e4a5dcb2a652db0904224f367c9b3c1470d5a7683c0480e582468b"
-            ],
-            "version": "==1.3.1"
-        },
-        "mccabe": {
-            "hashes": [
-                "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
-                "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
-            ],
-            "version": "==0.6.1"
         },
         "multidict": {
             "hashes": [
@@ -228,59 +173,6 @@
             ],
             "index": "pypi",
             "version": "==0.9.1"
-        },
-        "pylint": {
-            "hashes": [
-                "sha256:5d77031694a5fb97ea95e828c8d10fc770a1df6eb3906067aaed42201a8a6a09",
-                "sha256:723e3db49555abaf9bf79dc474c6b9e2935ad82230b10c1138a71ea41ac0fff1"
-            ],
-            "version": "==2.3.1"
-        },
-        "pylint-quotes": {
-            "hashes": [
-                "sha256:5332fa8b48ce5d8780df196d684f38c00614f8233fdc4c67efbdc0bbe7dc51d7",
-                "sha256:c53d2a63b4cd16c9fa426d243de6396910ff04c65001efdbea37427d401fce72"
-            ],
-            "index": "pypi",
-            "version": "==0.2.1"
-        },
-        "six": {
-            "hashes": [
-                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
-                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
-            ],
-            "version": "==1.12.0"
-        },
-        "typed-ast": {
-            "hashes": [
-                "sha256:035a54ede6ce1380599b2ce57844c6554666522e376bd111eb940fbc7c3dad23",
-                "sha256:037c35f2741ce3a9ac0d55abfcd119133cbd821fffa4461397718287092d9d15",
-                "sha256:049feae7e9f180b64efacbdc36b3af64a00393a47be22fa9cb6794e68d4e73d3",
-                "sha256:19228f7940beafc1ba21a6e8e070e0b0bfd1457902a3a81709762b8b9039b88d",
-                "sha256:2ea681e91e3550a30c2265d2916f40a5f5d89b59469a20f3bad7d07adee0f7a6",
-                "sha256:3a6b0a78af298d82323660df5497bcea0f0a4a25a0b003afd0ce5af049bd1f60",
-                "sha256:5385da8f3b801014504df0852bf83524599df890387a3c2b17b7caa3d78b1773",
-                "sha256:606d8afa07eef77280c2bf84335e24390055b478392e1975f96286d99d0cb424",
-                "sha256:69245b5b23bbf7fb242c9f8f08493e9ecd7711f063259aefffaeb90595d62287",
-                "sha256:6f6d839ab09830d59b7fa8fb6917023d8cb5498ee1f1dbd82d37db78eb76bc99",
-                "sha256:730888475f5ac0e37c1de4bd05eeb799fdb742697867f524dc8a4cd74bcecc23",
-                "sha256:9819b5162ffc121b9e334923c685b0d0826154e41dfe70b2ede2ce29034c71d8",
-                "sha256:9e60ef9426efab601dd9aa120e4ff560f4461cf8442e9c0a2b92548d52800699",
-                "sha256:af5fbdde0690c7da68e841d7fc2632345d570768ea7406a9434446d7b33b0ee1",
-                "sha256:b64efdbdf3bbb1377562c179f167f3bf301251411eb5ac77dec6b7d32bcda463",
-                "sha256:bac5f444c118aeb456fac1b0b5d14c6a71ea2a42069b09c176f75e9bd4c186f6",
-                "sha256:bda9068aafb73859491e13b99b682bd299c1b5fd50644d697533775828a28ee0",
-                "sha256:d659517ca116e6750101a1326107d3479028c5191f0ecee3c7203c50f5b915b0",
-                "sha256:eddd3fb1f3e0f82e5915a899285a39ee34ce18fd25d89582bc89fc9fb16cd2c6"
-            ],
-            "markers": "implementation_name == 'cpython'",
-            "version": "==1.3.1"
-        },
-        "wrapt": {
-            "hashes": [
-                "sha256:4aea003270831cceb8a90ff27c4031da6ead7ec1886023b80ce0dfe0adf61533"
-            ],
-            "version": "==1.11.1"
         },
         "yarl": {
             "hashes": [
@@ -469,6 +361,7 @@
                 "sha256:5d77031694a5fb97ea95e828c8d10fc770a1df6eb3906067aaed42201a8a6a09",
                 "sha256:723e3db49555abaf9bf79dc474c6b9e2935ad82230b10c1138a71ea41ac0fff1"
             ],
+            "index": "pypi",
             "version": "==2.3.1"
         },
         "pylint-quotes": {

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "7f5b1129e3bac22d61ccb973d5448cb50cb4ef5b68613c2f2bd424b1e6bddf66"
+            "sha256": "bb1ce9e9c0fda63e3ee91853bc3a45451a75b53a7ebaff127b32e89bf64edf1c"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -44,6 +44,13 @@
             "index": "pypi",
             "version": "==3.5.4"
         },
+        "astroid": {
+            "hashes": [
+                "sha256:6560e1e1749f68c64a4b5dee4e091fce798d2f0d84ebe638cf0e0585a343acf4",
+                "sha256:b65db1bbaac9f9f4d190199bb8680af6f6f84fd3769a5ea883df8a91fe68b4c4"
+            ],
+            "version": "==2.2.5"
+        },
         "async-timeout": {
             "hashes": [
                 "sha256:0c3c816a028d47f659d6ff5c745cb2acf1f966da1fe5c19c77a70282b25f4c5f",
@@ -53,10 +60,10 @@
         },
         "attrs": {
             "hashes": [
-                "sha256:10cbf6e27dbce8c30807caf056c8eb50917e0eaafe86347671b57254006c3e69",
-                "sha256:ca4be454458f9dec299268d472aaa5a11f67a4ff70093396e1ceae9c76cf4bbb"
+                "sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79",
+                "sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"
             ],
-            "version": "==18.2.0"
+            "version": "==19.1.0"
         },
         "chardet": {
             "hashes": [
@@ -64,14 +71,6 @@
                 "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
             ],
             "version": "==3.0.4"
-        },
-        "colorama": {
-            "hashes": [
-                "sha256:05eed71e2e327246ad6b38c540c4a3117230b19679b875190486ddd2d721422d",
-                "sha256:f8ac84de7840f5b9c4e3347b3c1eaa50f7e49c2b07596221daec5edaabbd7c48"
-            ],
-            "markers": "sys_platform == 'win32'",
-            "version": "==0.4.1"
         },
         "coloredlogs": {
             "hashes": [
@@ -83,11 +82,11 @@
         },
         "humanfriendly": {
             "hashes": [
-                "sha256:1d3a1c157602801c62dfdb321760229df2e0d4f14412a0f41b13ad3f930a936a",
-                "sha256:42d0aa829f59c710db20ec42eed24a8b7a27688d477da61b5aebd604d0bb2402"
+                "sha256:23057b10ad6f782e7bc3a20e3cb6768ab919f619bbdc0dd75691121bbde5591d",
+                "sha256:33ee8ceb63f1db61cce8b5c800c531e1a61023ac5488ccde2ba574a85be00a85"
             ],
             "index": "pypi",
-            "version": "==4.17"
+            "version": "==4.18"
         },
         "idna": {
             "hashes": [
@@ -95,6 +94,54 @@
                 "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
             ],
             "version": "==2.8"
+        },
+        "isort": {
+            "hashes": [
+                "sha256:18c796c2cd35eb1a1d3f012a214a542790a1aed95e29768bdcb9f2197eccbd0b",
+                "sha256:96151fca2c6e736503981896495d344781b60d18bfda78dc11b290c6125ebdb6"
+            ],
+            "version": "==4.3.15"
+        },
+        "lazy-object-proxy": {
+            "hashes": [
+                "sha256:0ce34342b419bd8f018e6666bfef729aec3edf62345a53b537a4dcc115746a33",
+                "sha256:1b668120716eb7ee21d8a38815e5eb3bb8211117d9a90b0f8e21722c0758cc39",
+                "sha256:209615b0fe4624d79e50220ce3310ca1a9445fd8e6d3572a896e7f9146bbf019",
+                "sha256:27bf62cb2b1a2068d443ff7097ee33393f8483b570b475db8ebf7e1cba64f088",
+                "sha256:27ea6fd1c02dcc78172a82fc37fcc0992a94e4cecf53cb6d73f11749825bd98b",
+                "sha256:2c1b21b44ac9beb0fc848d3993924147ba45c4ebc24be19825e57aabbe74a99e",
+                "sha256:2df72ab12046a3496a92476020a1a0abf78b2a7db9ff4dc2036b8dd980203ae6",
+                "sha256:320ffd3de9699d3892048baee45ebfbbf9388a7d65d832d7e580243ade426d2b",
+                "sha256:50e3b9a464d5d08cc5227413db0d1c4707b6172e4d4d915c1c70e4de0bbff1f5",
+                "sha256:5276db7ff62bb7b52f77f1f51ed58850e315154249aceb42e7f4c611f0f847ff",
+                "sha256:61a6cf00dcb1a7f0c773ed4acc509cb636af2d6337a08f362413c76b2b47a8dd",
+                "sha256:6ae6c4cb59f199d8827c5a07546b2ab7e85d262acaccaacd49b62f53f7c456f7",
+                "sha256:7661d401d60d8bf15bb5da39e4dd72f5d764c5aff5a86ef52a042506e3e970ff",
+                "sha256:7bd527f36a605c914efca5d3d014170b2cb184723e423d26b1fb2fd9108e264d",
+                "sha256:7cb54db3535c8686ea12e9535eb087d32421184eacc6939ef15ef50f83a5e7e2",
+                "sha256:7f3a2d740291f7f2c111d86a1c4851b70fb000a6c8883a59660d95ad57b9df35",
+                "sha256:81304b7d8e9c824d058087dcb89144842c8e0dea6d281c031f59f0acf66963d4",
+                "sha256:933947e8b4fbe617a51528b09851685138b49d511af0b6c0da2539115d6d4514",
+                "sha256:94223d7f060301b3a8c09c9b3bc3294b56b2188e7d8179c762a1cda72c979252",
+                "sha256:ab3ca49afcb47058393b0122428358d2fbe0408cf99f1b58b295cfeb4ed39109",
+                "sha256:bd6292f565ca46dee4e737ebcc20742e3b5be2b01556dafe169f6c65d088875f",
+                "sha256:cb924aa3e4a3fb644d0c463cad5bc2572649a6a3f68a7f8e4fbe44aaa6d77e4c",
+                "sha256:d0fc7a286feac9077ec52a927fc9fe8fe2fabab95426722be4c953c9a8bede92",
+                "sha256:ddc34786490a6e4ec0a855d401034cbd1242ef186c20d79d2166d6a4bd449577",
+                "sha256:e34b155e36fa9da7e1b7c738ed7767fc9491a62ec6af70fe9da4a057759edc2d",
+                "sha256:e5b9e8f6bda48460b7b143c3821b21b452cb3a835e6bbd5dd33aa0c8d3f5137d",
+                "sha256:e81ebf6c5ee9684be8f2c87563880f93eedd56dd2b6146d8a725b50b7e5adb0f",
+                "sha256:eb91be369f945f10d3a49f5f9be8b3d0b93a4c2be8f8a5b83b0571b8123e0a7a",
+                "sha256:f460d1ceb0e4a5dcb2a652db0904224f367c9b3c1470d5a7683c0480e582468b"
+            ],
+            "version": "==1.3.1"
+        },
+        "mccabe": {
+            "hashes": [
+                "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
+                "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
+            ],
+            "version": "==0.6.1"
         },
         "multidict": {
             "hashes": [
@@ -168,11 +215,11 @@
         },
         "pure-sasl": {
             "hashes": [
-                "sha256:25ba5dbb6eb25850a5e5509a8266f3bc506cf05eccacdb07613fbe82dc8a10f8",
-                "sha256:7bdd550a3c3f352a408cfd322e99b270589e838edd53fe10240b4a949b654a5d"
+                "sha256:54458deb9574e293aa58d820f4a94271770401409c4cd8b3dd86f1a827cffde7",
+                "sha256:83fcd41692ccccfa20f5cd1f621319ec07a31770e34dcc8bbb67940aa11533bc"
             ],
             "index": "pypi",
-            "version": "==0.5.1"
+            "version": "==0.6.1"
         },
         "pydle": {
             "hashes": [
@@ -182,12 +229,58 @@
             "index": "pypi",
             "version": "==0.9.1"
         },
-        "pyreadline": {
+        "pylint": {
             "hashes": [
-                "sha256:4530592fc2e85b25b1a9f79664433da09237c1a270e4d78ea5aa3a2c7229e2d1"
+                "sha256:5d77031694a5fb97ea95e828c8d10fc770a1df6eb3906067aaed42201a8a6a09",
+                "sha256:723e3db49555abaf9bf79dc474c6b9e2935ad82230b10c1138a71ea41ac0fff1"
             ],
-            "markers": "sys_platform == 'win32'",
-            "version": "==2.1"
+            "version": "==2.3.1"
+        },
+        "pylint-quotes": {
+            "hashes": [
+                "sha256:5332fa8b48ce5d8780df196d684f38c00614f8233fdc4c67efbdc0bbe7dc51d7",
+                "sha256:c53d2a63b4cd16c9fa426d243de6396910ff04c65001efdbea37427d401fce72"
+            ],
+            "index": "pypi",
+            "version": "==0.2.1"
+        },
+        "six": {
+            "hashes": [
+                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
+                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+            ],
+            "version": "==1.12.0"
+        },
+        "typed-ast": {
+            "hashes": [
+                "sha256:035a54ede6ce1380599b2ce57844c6554666522e376bd111eb940fbc7c3dad23",
+                "sha256:037c35f2741ce3a9ac0d55abfcd119133cbd821fffa4461397718287092d9d15",
+                "sha256:049feae7e9f180b64efacbdc36b3af64a00393a47be22fa9cb6794e68d4e73d3",
+                "sha256:19228f7940beafc1ba21a6e8e070e0b0bfd1457902a3a81709762b8b9039b88d",
+                "sha256:2ea681e91e3550a30c2265d2916f40a5f5d89b59469a20f3bad7d07adee0f7a6",
+                "sha256:3a6b0a78af298d82323660df5497bcea0f0a4a25a0b003afd0ce5af049bd1f60",
+                "sha256:5385da8f3b801014504df0852bf83524599df890387a3c2b17b7caa3d78b1773",
+                "sha256:606d8afa07eef77280c2bf84335e24390055b478392e1975f96286d99d0cb424",
+                "sha256:69245b5b23bbf7fb242c9f8f08493e9ecd7711f063259aefffaeb90595d62287",
+                "sha256:6f6d839ab09830d59b7fa8fb6917023d8cb5498ee1f1dbd82d37db78eb76bc99",
+                "sha256:730888475f5ac0e37c1de4bd05eeb799fdb742697867f524dc8a4cd74bcecc23",
+                "sha256:9819b5162ffc121b9e334923c685b0d0826154e41dfe70b2ede2ce29034c71d8",
+                "sha256:9e60ef9426efab601dd9aa120e4ff560f4461cf8442e9c0a2b92548d52800699",
+                "sha256:af5fbdde0690c7da68e841d7fc2632345d570768ea7406a9434446d7b33b0ee1",
+                "sha256:b64efdbdf3bbb1377562c179f167f3bf301251411eb5ac77dec6b7d32bcda463",
+                "sha256:bac5f444c118aeb456fac1b0b5d14c6a71ea2a42069b09c176f75e9bd4c186f6",
+                "sha256:bda9068aafb73859491e13b99b682bd299c1b5fd50644d697533775828a28ee0",
+                "sha256:d659517ca116e6750101a1326107d3479028c5191f0ecee3c7203c50f5b915b0",
+                "sha256:eddd3fb1f3e0f82e5915a899285a39ee34ce18fd25d89582bc89fc9fb16cd2c6"
+            ],
+            "markers": "implementation_name == 'cpython'",
+            "version": "==1.3.1"
+        },
+        "wrapt": {
+            "hashes": [
+                "sha256:4aea003270831cceb8a90ff27c4031da6ead7ec1886023b80ce0dfe0adf61533"
+            ],
+            "version": "==1.11.1"
         },
         "yarl": {
             "hashes": [
@@ -209,10 +302,10 @@
     "develop": {
         "astroid": {
             "hashes": [
-                "sha256:35b032003d6a863f5dcd7ec11abd5cd5893428beaa31ab164982403bcb311f22",
-                "sha256:6a5d668d7dc69110de01cdf7aeec69a679ef486862a0850cc0fd5571505b6b7e"
+                "sha256:6560e1e1749f68c64a4b5dee4e091fce798d2f0d84ebe638cf0e0585a343acf4",
+                "sha256:b65db1bbaac9f9f4d190199bb8680af6f6f84fd3769a5ea883df8a91fe68b4c4"
             ],
-            "version": "==2.1.0"
+            "version": "==2.2.5"
         },
         "atomicwrites": {
             "hashes": [
@@ -223,17 +316,17 @@
         },
         "attrs": {
             "hashes": [
-                "sha256:10cbf6e27dbce8c30807caf056c8eb50917e0eaafe86347671b57254006c3e69",
-                "sha256:ca4be454458f9dec299268d472aaa5a11f67a4ff70093396e1ceae9c76cf4bbb"
+                "sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79",
+                "sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"
             ],
-            "version": "==18.2.0"
+            "version": "==19.1.0"
         },
         "certifi": {
             "hashes": [
-                "sha256:47f9c83ef4c0c621eaef743f133f09fa8a74a9b75f037e8624f83bd1b6626cb7",
-                "sha256:993f830721089fef441cdfeb4b2c8c9df86f0c63239f06bd025a76a7daddb033"
+                "sha256:59b7658e26ca9c7339e00f8f4636cdfe59d34fa37b9b04f6f9e9926b3cece1a5",
+                "sha256:b26104d6835d1f5e49452a26eb2ff87fe7090b89dfcaee5ea2212697e1e1d7ae"
             ],
-            "version": "==2018.11.29"
+            "version": "==2019.3.9"
         },
         "chardet": {
             "hashes": [
@@ -250,49 +343,41 @@
             "index": "pypi",
             "version": "==2.0.15"
         },
-        "colorama": {
-            "hashes": [
-                "sha256:05eed71e2e327246ad6b38c540c4a3117230b19679b875190486ddd2d721422d",
-                "sha256:f8ac84de7840f5b9c4e3347b3c1eaa50f7e49c2b07596221daec5edaabbd7c48"
-            ],
-            "markers": "sys_platform == 'win32'",
-            "version": "==0.4.1"
-        },
         "coverage": {
             "hashes": [
-                "sha256:09e47c529ff77bf042ecfe858fb55c3e3eb97aac2c87f0349ab5a7efd6b3939f",
-                "sha256:0a1f9b0eb3aa15c990c328535655847b3420231af299386cfe5efc98f9c250fe",
-                "sha256:0cc941b37b8c2ececfed341444a456912e740ecf515d560de58b9a76562d966d",
-                "sha256:10e8af18d1315de936d67775d3a814cc81d0747a1a0312d84e27ae5610e313b0",
-                "sha256:1b4276550b86caa60606bd3572b52769860a81a70754a54acc8ba789ce74d607",
-                "sha256:1e8a2627c48266c7b813975335cfdea58c706fe36f607c97d9392e61502dc79d",
-                "sha256:2b224052bfd801beb7478b03e8a66f3f25ea56ea488922e98903914ac9ac930b",
-                "sha256:447c450a093766744ab53bf1e7063ec82866f27bcb4f4c907da25ad293bba7e3",
-                "sha256:46101fc20c6f6568561cdd15a54018bb42980954b79aa46da8ae6f008066a30e",
-                "sha256:4710dc676bb4b779c4361b54eb308bc84d64a2fa3d78e5f7228921eccce5d815",
-                "sha256:510986f9a280cd05189b42eee2b69fecdf5bf9651d4cd315ea21d24a964a3c36",
-                "sha256:5535dda5739257effef56e49a1c51c71f1d37a6e5607bb25a5eee507c59580d1",
-                "sha256:5a7524042014642b39b1fcae85fb37556c200e64ec90824ae9ecf7b667ccfc14",
-                "sha256:5f55028169ef85e1fa8e4b8b1b91c0b3b0fa3297c4fb22990d46ff01d22c2d6c",
-                "sha256:6694d5573e7790a0e8d3d177d7a416ca5f5c150742ee703f3c18df76260de794",
-                "sha256:6831e1ac20ac52634da606b658b0b2712d26984999c9d93f0c6e59fe62ca741b",
-                "sha256:77f0d9fa5e10d03aa4528436e33423bfa3718b86c646615f04616294c935f840",
-                "sha256:828ad813c7cdc2e71dcf141912c685bfe4b548c0e6d9540db6418b807c345ddd",
-                "sha256:85a06c61598b14b015d4df233d249cd5abfa61084ef5b9f64a48e997fd829a82",
-                "sha256:8cb4febad0f0b26c6f62e1628f2053954ad2c555d67660f28dfb1b0496711952",
-                "sha256:a5c58664b23b248b16b96253880b2868fb34358911400a7ba39d7f6399935389",
-                "sha256:aaa0f296e503cda4bc07566f592cd7a28779d433f3a23c48082af425d6d5a78f",
-                "sha256:ab235d9fe64833f12d1334d29b558aacedfbca2356dfb9691f2d0d38a8a7bfb4",
-                "sha256:b3b0c8f660fae65eac74fbf003f3103769b90012ae7a460863010539bb7a80da",
-                "sha256:bab8e6d510d2ea0f1d14f12642e3f35cefa47a9b2e4c7cea1852b52bc9c49647",
-                "sha256:c45297bbdbc8bb79b02cf41417d63352b70bcb76f1bbb1ee7d47b3e89e42f95d",
-                "sha256:d19bca47c8a01b92640c614a9147b081a1974f69168ecd494687c827109e8f42",
-                "sha256:d64b4340a0c488a9e79b66ec9f9d77d02b99b772c8b8afd46c1294c1d39ca478",
-                "sha256:da969da069a82bbb5300b59161d8d7c8d423bc4ccd3b410a9b4d8932aeefc14b",
-                "sha256:ed02c7539705696ecb7dc9d476d861f3904a8d2b7e894bd418994920935d36bb",
-                "sha256:ee5b8abc35b549012e03a7b1e86c09491457dba6c94112a2482b18589cc2bdb9"
+                "sha256:3684fabf6b87a369017756b551cef29e505cb155ddb892a7a29277b978da88b9",
+                "sha256:39e088da9b284f1bd17c750ac672103779f7954ce6125fd4382134ac8d152d74",
+                "sha256:3c205bc11cc4fcc57b761c2da73b9b72a59f8d5ca89979afb0c1c6f9e53c7390",
+                "sha256:465ce53a8c0f3a7950dfb836438442f833cf6663d407f37d8c52fe7b6e56d7e8",
+                "sha256:48020e343fc40f72a442c8a1334284620f81295256a6b6ca6d8aa1350c763bbe",
+                "sha256:5296fc86ab612ec12394565c500b412a43b328b3907c0d14358950d06fd83baf",
+                "sha256:5f61bed2f7d9b6a9ab935150a6b23d7f84b8055524e7be7715b6513f3328138e",
+                "sha256:68a43a9f9f83693ce0414d17e019daee7ab3f7113a70c79a3dd4c2f704e4d741",
+                "sha256:6b8033d47fe22506856fe450470ccb1d8ba1ffb8463494a15cfc96392a288c09",
+                "sha256:7ad7536066b28863e5835e8cfeaa794b7fe352d99a8cded9f43d1161be8e9fbd",
+                "sha256:7bacb89ccf4bedb30b277e96e4cc68cd1369ca6841bde7b005191b54d3dd1034",
+                "sha256:839dc7c36501254e14331bcb98b27002aa415e4af7ea039d9009409b9d2d5420",
+                "sha256:8f9a95b66969cdea53ec992ecea5406c5bd99c9221f539bca1e8406b200ae98c",
+                "sha256:932c03d2d565f75961ba1d3cec41ddde00e162c5b46d03f7423edcb807734eab",
+                "sha256:988529edadc49039d205e0aa6ce049c5ccda4acb2d6c3c5c550c17e8c02c05ba",
+                "sha256:998d7e73548fe395eeb294495a04d38942edb66d1fa61eb70418871bc621227e",
+                "sha256:9de60893fb447d1e797f6bf08fdf0dbcda0c1e34c1b06c92bd3a363c0ea8c609",
+                "sha256:9e80d45d0c7fcee54e22771db7f1b0b126fb4a6c0a2e5afa72f66827207ff2f2",
+                "sha256:a545a3dfe5082dc8e8c3eb7f8a2cf4f2870902ff1860bd99b6198cfd1f9d1f49",
+                "sha256:a5d8f29e5ec661143621a8f4de51adfb300d7a476224156a39a392254f70687b",
+                "sha256:aca06bfba4759bbdb09bf52ebb15ae20268ee1f6747417837926fae990ebc41d",
+                "sha256:bb23b7a6fd666e551a3094ab896a57809e010059540ad20acbeec03a154224ce",
+                "sha256:bfd1d0ae7e292105f29d7deaa9d8f2916ed8553ab9d5f39ec65bcf5deadff3f9",
+                "sha256:c62ca0a38958f541a73cf86acdab020c2091631c137bd359c4f5bddde7b75fd4",
+                "sha256:c709d8bda72cf4cd348ccec2a4881f2c5848fd72903c185f363d361b2737f773",
+                "sha256:c968a6aa7e0b56ecbd28531ddf439c2ec103610d3e2bf3b75b813304f8cb7723",
+                "sha256:df785d8cb80539d0b55fd47183264b7002077859028dfe3070cf6359bf8b2d9c",
+                "sha256:f406628ca51e0ae90ae76ea8398677a921b36f0bd71aab2099dfed08abd0322f",
+                "sha256:f46087bbd95ebae244a0eda01a618aff11ec7a069b15a3ef8f6b520db523dcf1",
+                "sha256:f8019c5279eb32360ca03e9fac40a12667715546eed5c5eb59eb381f2f501260",
+                "sha256:fc5f4d209733750afd2714e9109816a29500718b32dd9a5db01c0cb3a019b96a"
             ],
-            "version": "==4.5.2"
+            "version": "==4.5.3"
         },
         "idna": {
             "hashes": [
@@ -303,11 +388,10 @@
         },
         "isort": {
             "hashes": [
-                "sha256:1153601da39a25b14ddc54955dbbacbb6b2d19135386699e2ad58517953b34af",
-                "sha256:b9c40e9750f3d77e6e4d441d8b0266cf555e7cdabdcff33c4fd06366ca761ef8",
-                "sha256:ec9ef8f4a9bc6f71eec99e1806bfa2de401650d996c59330782b89a5555c1497"
+                "sha256:18c796c2cd35eb1a1d3f012a214a542790a1aed95e29768bdcb9f2197eccbd0b",
+                "sha256:96151fca2c6e736503981896495d344781b60d18bfda78dc11b290c6125ebdb6"
             ],
-            "version": "==4.3.4"
+            "version": "==4.3.15"
         },
         "lazy-object-proxy": {
             "hashes": [
@@ -352,25 +436,25 @@
         },
         "more-itertools": {
             "hashes": [
-                "sha256:38a936c0a6d98a38bcc2d03fdaaedaba9f412879461dd2ceff8d37564d6522e4",
-                "sha256:c0a5785b1109a6bd7fac76d6837fd1feca158e54e521ccd2ae8bfe393cc9d4fc",
-                "sha256:fe7a7cae1ccb57d33952113ff4fa1bc5f879963600ed74918f1236e212ee50b9"
+                "sha256:0125e8f60e9e031347105eb1682cef932f5e97d7b9a1a28d9bf00c22a5daef40",
+                "sha256:590044e3942351a1bdb1de960b739ff4ce277960f2425ad4509446dbace8d9d1"
             ],
-            "version": "==5.0.0"
+            "markers": "python_version > '2.7'",
+            "version": "==6.0.0"
         },
         "pluggy": {
             "hashes": [
-                "sha256:8ddc32f03971bfdf900a81961a48ccf2fb677cf7715108f85295c67405798616",
-                "sha256:980710797ff6a041e9a73a5787804f848996ecaa6f8a1b1e08224a5894f2074a"
+                "sha256:19ecf9ce9db2fce065a7a0586e07cfb4ac8614fe96edf628a264b1c70116cf8f",
+                "sha256:84d306a647cc805219916e62aab89caa97a33a1dd8c342e87a37f91073cd4746"
             ],
-            "version": "==0.8.1"
+            "version": "==0.9.0"
         },
         "py": {
             "hashes": [
-                "sha256:bf92637198836372b520efcba9e020c330123be8ce527e535d185ed4b6f45694",
-                "sha256:e76826342cefe3c3d5f7e8ee4316b80d1dd8a300781612ddbc765c17ba25a6c6"
+                "sha256:64f65755aee5b381cea27766a3a147c3f15b9b6b9ac88676de66ba2ae36793fa",
+                "sha256:dc639b046a6e2cff5bbe40194ad65936d6ba360b52b3c3fe1d08a82dd50b5e53"
             ],
-            "version": "==1.7.0"
+            "version": "==1.8.0"
         },
         "pycodestyle": {
             "hashes": [
@@ -382,19 +466,26 @@
         },
         "pylint": {
             "hashes": [
-                "sha256:689de29ae747642ab230c6d37be2b969bf75663176658851f456619aacf27492",
-                "sha256:771467c434d0d9f081741fec1d64dfb011ed26e65e12a28fe06ca2f61c4d556c"
+                "sha256:5d77031694a5fb97ea95e828c8d10fc770a1df6eb3906067aaed42201a8a6a09",
+                "sha256:723e3db49555abaf9bf79dc474c6b9e2935ad82230b10c1138a71ea41ac0fff1"
+            ],
+            "version": "==2.3.1"
+        },
+        "pylint-quotes": {
+            "hashes": [
+                "sha256:5332fa8b48ce5d8780df196d684f38c00614f8233fdc4c67efbdc0bbe7dc51d7",
+                "sha256:c53d2a63b4cd16c9fa426d243de6396910ff04c65001efdbea37427d401fce72"
             ],
             "index": "pypi",
-            "version": "==2.2.2"
+            "version": "==0.2.1"
         },
         "pytest": {
             "hashes": [
-                "sha256:65aeaa77ae87c7fc95de56285282546cfa9c886dc8e5dc78313db1c25e21bc07",
-                "sha256:6ac6d467d9f053e95aaacd79f831dbecfe730f419c6c7022cb316b365cd9199d"
+                "sha256:592eaa2c33fae68c7d75aacf042efc9f77b27c08a6224a4f59beab8d9a420523",
+                "sha256:ad3ad5c450284819ecde191a654c09b0ec72257a2c711b9633d677c71c9850c4"
             ],
             "index": "pypi",
-            "version": "==4.2.0"
+            "version": "==4.3.1"
         },
         "pytest-asyncio": {
             "hashes": [
@@ -414,11 +505,11 @@
         },
         "pytest-httpserver": {
             "hashes": [
-                "sha256:94e4a9063d34222ee386eeca8d4cdd48c2870270b22bcd2d3f3ce2505ae56893",
-                "sha256:cee2ef07b753bc7e7d5432d69a62c5099eb184dc095a5d5eeb5b3a3564d92e3c"
+                "sha256:689391ad6bef74f4c9d4d0d1bb2b239a87a780431012fdbdd6f96fac0251c544",
+                "sha256:8a900fdcc75aad86383ae9453dde707fb948fdded1e467ccafc34fa4a0ca7ef8"
             ],
             "index": "pypi",
-            "version": "==0.2.1"
+            "version": "==0.3.0"
         },
         "requests": {
             "hashes": [
@@ -433,6 +524,31 @@
                 "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
             ],
             "version": "==1.12.0"
+        },
+        "typed-ast": {
+            "hashes": [
+                "sha256:035a54ede6ce1380599b2ce57844c6554666522e376bd111eb940fbc7c3dad23",
+                "sha256:037c35f2741ce3a9ac0d55abfcd119133cbd821fffa4461397718287092d9d15",
+                "sha256:049feae7e9f180b64efacbdc36b3af64a00393a47be22fa9cb6794e68d4e73d3",
+                "sha256:19228f7940beafc1ba21a6e8e070e0b0bfd1457902a3a81709762b8b9039b88d",
+                "sha256:2ea681e91e3550a30c2265d2916f40a5f5d89b59469a20f3bad7d07adee0f7a6",
+                "sha256:3a6b0a78af298d82323660df5497bcea0f0a4a25a0b003afd0ce5af049bd1f60",
+                "sha256:5385da8f3b801014504df0852bf83524599df890387a3c2b17b7caa3d78b1773",
+                "sha256:606d8afa07eef77280c2bf84335e24390055b478392e1975f96286d99d0cb424",
+                "sha256:69245b5b23bbf7fb242c9f8f08493e9ecd7711f063259aefffaeb90595d62287",
+                "sha256:6f6d839ab09830d59b7fa8fb6917023d8cb5498ee1f1dbd82d37db78eb76bc99",
+                "sha256:730888475f5ac0e37c1de4bd05eeb799fdb742697867f524dc8a4cd74bcecc23",
+                "sha256:9819b5162ffc121b9e334923c685b0d0826154e41dfe70b2ede2ce29034c71d8",
+                "sha256:9e60ef9426efab601dd9aa120e4ff560f4461cf8442e9c0a2b92548d52800699",
+                "sha256:af5fbdde0690c7da68e841d7fc2632345d570768ea7406a9434446d7b33b0ee1",
+                "sha256:b64efdbdf3bbb1377562c179f167f3bf301251411eb5ac77dec6b7d32bcda463",
+                "sha256:bac5f444c118aeb456fac1b0b5d14c6a71ea2a42069b09c176f75e9bd4c186f6",
+                "sha256:bda9068aafb73859491e13b99b682bd299c1b5fd50644d697533775828a28ee0",
+                "sha256:d659517ca116e6750101a1326107d3479028c5191f0ecee3c7203c50f5b915b0",
+                "sha256:eddd3fb1f3e0f82e5915a899285a39ee34ce18fd25d89582bc89fc9fb16cd2c6"
+            ],
+            "markers": "implementation_name == 'cpython'",
+            "version": "==1.3.1"
         },
         "urllib3": {
             "hashes": [

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -45,22 +45,22 @@ async def start():
 
     auth_method = config["authentication"]["method"]
     if auth_method == "PLAIN":
-        client_args["sasl_username"] = config['authentication']['plain']['username']
-        client_args["sasl_password"] = config['authentication']['plain']['password']
-        client_args["sasl_identity"] = config['authentication']['plain']['identity']
+        client_args["sasl_username"] = config["authentication"]["plain"]["username"]
+        client_args["sasl_password"] = config["authentication"]["plain"]["password"]
+        client_args["sasl_identity"] = config["authentication"]["plain"]["identity"]
         LOG.info("Authenticating via SASL PLAIN.")
     elif auth_method == "EXTERNAL":
         client_args["sasl_mechanism"] = "EXTERNAL"
-        cert = config['authentication']['external']['tls_client_cert']
+        cert = config["authentication"]["external"]["tls_client_cert"]
         client_args["tls_client_cert"] = f"certs/{cert}"
         LOG.info(f"Authenticating using client certificate at {cert}.")
     else:
         raise ValueError(f"unknown authentication mechanism {auth_method}")
 
     client = MechaClient(**client_args)
-    await client.connect(hostname=config['irc']['server'],
-                         port=config['irc']['port'],
-                         tls=config['irc']['tls'],
+    await client.connect(hostname=config["irc"]["server"],
+                         port=config["irc"]["port"],
+                         tls=config["irc"]["tls"],
                          )
 
     LOG.info("Connected to IRC.")

--- a/src/mechaclient.py
+++ b/src/mechaclient.py
@@ -80,7 +80,7 @@ class MechaClient(Client):
         """
         LOG.debug(f"{channel}: <{user}> {message}")
 
-        if user == config['irc']['nickname']:
+        if user == config["irc"]["nickname"]:
             # don't do this and the bot can get int o an infinite
             # self-stimulated positive feedback loop.
             LOG.debug(f"Ignored {message} (anti-loop)")

--- a/src/packages/cache/rat_cache.py
+++ b/src/packages/cache/rat_cache.py
@@ -31,8 +31,8 @@ class RatCache(Singleton):
         """
         if not hasattr(self, "_initalized"):
             self._initalized = True
-            self._cache_by_id: Dict[UUID, 'Rat'] = {}
-            self._cache_by_name: Dict[str, 'Rat'] = {}
+            self._cache_by_id: Dict[UUID, "Rat"] = {}
+            self._cache_by_name: Dict[str, "Rat"] = {}
             self._api_handler = api_handler
 
     @property
@@ -48,7 +48,7 @@ class RatCache(Singleton):
         # FIXME: add type check once the API gets merged in
 
     @property
-    def by_uuid(self) -> Dict[UUID, 'Rat']:
+    def by_uuid(self) -> Dict[UUID, "Rat"]:
         """
         Cache indexed by rat's UUID
 
@@ -58,7 +58,7 @@ class RatCache(Singleton):
         return self._cache_by_id
 
     @by_uuid.setter
-    def by_uuid(self, value: Dict[UUID, 'Rat']) -> None:
+    def by_uuid(self, value: Dict[UUID, "Rat"]) -> None:
         """
         Sets the ratcache's by_uuid property
 
@@ -76,7 +76,7 @@ class RatCache(Singleton):
         self._cache_by_id = value
 
     @property
-    def by_name(self) -> Dict[str, 'Rat']:
+    def by_name(self) -> Dict[str, "Rat"]:
         """
         Rats cache indexed by rat names
 
@@ -86,14 +86,14 @@ class RatCache(Singleton):
         return self._cache_by_name
 
     @by_name.setter
-    def by_name(self, value: Dict[str, 'Rat']) -> None:
+    def by_name(self, value: Dict[str, "Rat"]) -> None:
         if not isinstance(value, Dict):
             raise TypeError(f"expected a dict, got {type(value)}")
         self._cache_by_name = value
 
     async def get_rat_by_name(self, name: str,
                               platform: Optional[Platforms] = None,
-                              ) -> 'Rat' or None:
+                              ) -> "Rat" or None:
         """
         Finds a rat by name and optionally by platform
 
@@ -127,7 +127,7 @@ class RatCache(Singleton):
             # we found a rat
             return found if (found.platform == platform or platform is None) else None
 
-    async def get_rat_by_uuid(self, uuid: UUID) -> Optional['Rat']:
+    async def get_rat_by_uuid(self, uuid: UUID) -> Optional["Rat"]:
         """
         Finds a rat by their UUID.
 

--- a/src/packages/commands/rat_command.py
+++ b/src/packages/commands/rat_command.py
@@ -43,7 +43,7 @@ class NameCollisionException(CommandException):
 _registered_commands = {}  # pylint: disable=invalid-name
 
 # character/s that must prefix a message for it to be parsed as a command.
-PREFIX = config['commands']['prefix']
+PREFIX = config["commands"]["prefix"]
 
 
 async def trigger(ctx) -> Any:

--- a/src/packages/context/context.py
+++ b/src/packages/context/context.py
@@ -18,7 +18,7 @@ from ..user import User
 if TYPE_CHECKING:
     from src.mechaclient import MechaClient
 
-PREFIX = config['commands']['prefix']
+PREFIX = config["commands"]["prefix"]
 
 
 class Context:
@@ -26,7 +26,7 @@ class Context:
     Command context, stores the context of a command's invocation
     """
 
-    def __init__(self, bot: 'MechaClient',
+    def __init__(self, bot: "MechaClient",
                  user: User,
                  target: str,
                  words: [str],
@@ -45,7 +45,7 @@ class Context:
             prefixed (bool): marker if the message is prefixed
         """
         self._user: User = user
-        self._bot: 'MechaClient' = bot
+        self._bot: "MechaClient" = bot
         self._target: str = target
         self._words: [str] = words
         self._words_eol: [str] = words_eol
@@ -71,7 +71,7 @@ class Context:
         return self._user
 
     @property
-    def bot(self) -> 'MechaClient':
+    def bot(self) -> "MechaClient":
         """
         MechaClient instance
 
@@ -118,7 +118,7 @@ class Context:
         return self.target if self.bot.is_channel(self.target) else None
 
     @classmethod
-    async def from_message(cls, bot: 'MechaClient', channel: str, sender: str, message: str):
+    async def from_message(cls, bot: "MechaClient", channel: str, sender: str, message: str):
         """
         Creates a context from a IRC message
 
@@ -174,7 +174,7 @@ def _split_message(string: str) -> Tuple[List[str], List[str]]:
 
     Example:
         >>> _split_message("pink fluffy unicorns")
-        (['pink', 'fluffy', 'unicorns'], ['pink fluffy unicorns', 'fluffy unicorns', 'unicorns'])
+        (["pink", "fluffy", "unicorns"], ["pink fluffy unicorns", "fluffy unicorns", "unicorns"])
     """
     words = []
     words_eol = []

--- a/src/packages/database/database_manager.py
+++ b/src/packages/database/database_manager.py
@@ -25,11 +25,11 @@ class DatabaseManager:
     ODBC drivers are not required on Windows.
 
         Usage:
-        >>> DatabaseManager(dbhost='DatabaseServer.org',
+        >>> DatabaseManager(dbhost="DatabaseServer.org",
         ...                 dbport=5432,
-        ...                 dbname='DatabaseName',
-        ...                 dbuser='DatabaseUserName',
-        ...                 dbpassword='UserPassword') # doctest: +SKIP
+        ...                 dbname="DatabaseName",
+        ...                 dbuser="DatabaseUserName",
+        ...                 dbpassword="UserPassword") # doctest: +SKIP
 
         All arguments are optional.  If omitted, config values will be pulled from config file.
 
@@ -49,7 +49,7 @@ class DatabaseManager:
         >>> query = sql.SQL(
         ... "SELECT FROM public.table WHERE table.name=%s AND table.lang=%s AND table.something=%s")
 
-        >>> dbm.query(query, ('tuple','of','values'))# doctest: +SKIP
+        >>> dbm.query(query, ("tuple","of","values"))# doctest: +SKIP
 
     """
 
@@ -66,20 +66,20 @@ class DatabaseManager:
 
             # Utilize function arguments if they are provided,
             # otherwise retrieve from config file and use those values.
-            self._dbhost = dbhost if dbhost is not None else config['database'].get('host')
+            self._dbhost = dbhost if dbhost is not None else config["database"].get("host")
             assert self._dbhost
 
-            self._dbport = dbport if dbhost is not None else config['database'].get('port')
+            self._dbport = dbport if dbhost is not None else config["database"].get("port")
             assert self._dbport
 
-            self._dbname = dbname if dbname is not None else config['database'].get('dbname')
+            self._dbname = dbname if dbname is not None else config["database"].get("dbname")
             assert self._dbname
 
-            self._dbuser = dbuser if dbuser is not None else config['database'].get('username')
+            self._dbuser = dbuser if dbuser is not None else config["database"].get("username")
             assert self._dbuser
 
             self._dbpass = dbpassword if dbpassword is not None else \
-                config['database'].get('password')
+                config["database"].get("password")
             assert self._dbpass
 
         # Create Database Connections Pool
@@ -119,7 +119,7 @@ class DatabaseManager:
             # If we could set these at connection time, we would,
             # but they must be set outside the pool.
             connection.autocommit = True
-            connection.set_client_encoding('utf-8')
+            connection.set_client_encoding("utf-8")
             # Create cursor, and execute the query.
             with connection.cursor() as cursor:
                 cursor.execute(query, values)

--- a/src/packages/epic/epic.py
+++ b/src/packages/epic/epic.py
@@ -27,7 +27,7 @@ class Epic:
     def __init__(self,
                  uuid: UUID,
                  notes: str,
-                 rescue: Optional['Rescue'] = None,
+                 rescue: Optional["Rescue"] = None,
                  rat: Optional[Rat] = None):
         """
         Creates a new Epic object.
@@ -43,7 +43,7 @@ class Epic:
         self._hash: Optional[int] = None
         self._uuid: uuid = uuid
         self._notes: str = notes
-        self._rescue: 'Rescue' = rescue
+        self._rescue: "Rescue" = rescue
         self._rat: Rat = rat
 
     @property
@@ -67,7 +67,7 @@ class Epic:
         return self._notes
 
     @property
-    def rescue(self) -> 'Rescue':
+    def rescue(self) -> "Rescue":
         """
         Associated epic rescue
 
@@ -86,7 +86,7 @@ class Epic:
         """
         return self._rat
 
-    def __eq__(self, other: 'Epic') -> bool:
+    def __eq__(self, other: "Epic") -> bool:
         # type and null check
         if not isinstance(other, Epic):
             return NotImplemented

--- a/src/packages/fact_manager/fact.py
+++ b/src/packages/fact_manager/fact.py
@@ -21,7 +21,7 @@ class Fact:
 
     def __init__(self, name, message,
                  aliases, author, edited,
-                 editedby, mfd=False, lang='en'):
+                 editedby, mfd=False, lang="en"):
         self._name = name
         self._lang = lang
         self._message = message

--- a/src/packages/fact_manager/fact_manager.py
+++ b/src/packages/fact_manager/fact_manager.py
@@ -167,7 +167,7 @@ class FactManager(DatabaseManager):
             LOG.exception(f"Editing fact '{name}-{lang}' failed.")
             raise error
         else:
-            await self.add_transaction(fact_name=name, fact_lang=lang, author=editor, msg='Edited',
+            await self.add_transaction(fact_name=name, fact_lang=lang, author=editor, msg="Edited",
                                        new_field=new_message, old_field=current_fact.message)
 
     async def exists(self, name: str, lang: str) -> bool:

--- a/src/packages/galaxy/galaxy.py
+++ b/src/packages/galaxy/galaxy.py
@@ -27,41 +27,41 @@ class Galaxy:
     """
 
     LANDMARK_SYSTEMS = {
-        'beagle point': StarSystem(
-            name='BEAGLE POINT',
+        "beagle point": StarSystem(
+            name="BEAGLE POINT",
             position=Vector(-1111.5625, -134.21875, 65269.75),
-            spectral_class='K'
+            spectral_class="K"
         ),
-        'colonia': StarSystem(
-            name='COLONIA',
+        "colonia": StarSystem(
+            name="COLONIA",
             position=Vector(-9530.5, -910.28125, 19808.125),
-            spectral_class='F'
+            spectral_class="F"
         ),
-        'fuelum': StarSystem(
-            name='FUELUM',
+        "fuelum": StarSystem(
+            name="FUELUM",
             position=Vector(52, -52.65625, 49.8125),
-            spectral_class='K'
+            spectral_class="K"
         ),
-        'rodentia': StarSystem(
-            name='RODENTIA',
+        "rodentia": StarSystem(
+            name="RODENTIA",
             position=Vector(-9530.53125, -907.25, 19787.375),
-            spectral_class='M'
+            spectral_class="M"
         ),
-        'sagittarius a*': StarSystem(
-            name='SAGITTARIUS A*',
+        "sagittarius a*": StarSystem(
+            name="SAGITTARIUS A*",
             position=Vector(25.21875, -20.90625, 25899.96875),
             spectral_class=None
         ),
-        'sol': StarSystem(
-            name='SOL',
+        "sol": StarSystem(
+            name="SOL",
             position=Vector.zero(),
-            spectral_class='G'
+            spectral_class="G"
         )
     }
     MAX_PLOT_DISTANCE = 20000
 
     def __init__(self, url: str = None):
-        self.url = url or config['api']['url']
+        self.url = url or config["api"]["url"]
 
     async def find_system_by_name(self, name: str) -> Optional[StarSystem]:
         """
@@ -78,17 +78,17 @@ class Galaxy:
             return self.LANDMARK_SYSTEMS[name.casefold()]
 
         data = await self._call("api/systems", {"filter[name:eq]": name.upper()})
-        result_count = data['meta']['results']['available']
+        result_count = data["meta"]["results"]["available"]
         if result_count > 0:
-            sys = data['data'][0]['attributes']
+            sys = data["data"][0]["attributes"]
             main_star = await self._call("api/stars",
-                                         {"filter[systemId64:eq]": sys['id64'],
+                                         {"filter[systemId64:eq]": sys["id64"],
                                           "filter[isMainStar:eq]": 1})
-            if main_star['meta']['results']['available'] > 0:
-                sys['spectral_class'] = main_star['data'][0]['attributes']['subType'][0]
-            return StarSystem(position=Vector(**sys['coords']),
-                              name=sys['name'],
-                              spectral_class=sys.get('spectral_class'))
+            if main_star["meta"]["results"]["available"] > 0:
+                sys["spectral_class"] = main_star["data"][0]["attributes"]["subType"][0]
+            return StarSystem(position=Vector(**sys["coords"]),
+                              name=sys["name"],
+                              spectral_class=sys.get("spectral_class"))
 
     async def find_nearest_landmark(self, system: StarSystem) -> Tuple[StarSystem, float]:
         """
@@ -138,8 +138,8 @@ class Galaxy:
                                     "type": "dmeta",
                                     "limit": "5"})
         # Check to ensure the data set is not missing or empty.
-        if matches['data']:
-            return [match['name'] for match in matches['data']]
+        if matches["data"]:
+            return [match["name"] for match in matches["data"]]
 
     async def plot_waypoint_route(self,
                                   start: str,
@@ -249,8 +249,8 @@ class Galaxy:
                                     "aggressive": "1",
                                     "limit": limit,
                                     "cubesize": cubesize})
-        if nearest['data']:
-            return [neighbor['name'] for neighbor in nearest['data']]
+        if nearest["data"]:
+            return [neighbor["name"] for neighbor in nearest["data"]]
 
     async def _call(self, endpoint: str, params: Dict[str, str]) -> object:
         """
@@ -267,7 +267,7 @@ class Galaxy:
         base_url = self.url
         param_string = ""
         if params:
-            param_string = '&'.join(
+            param_string = "&".join(
                 [f"{key}={escape(str(value))}" for key, value in params.items()]
             )
         url = f"{base_url}{endpoint}?{param_string}"

--- a/src/packages/galaxy/star_system.py
+++ b/src/packages/galaxy/star_system.py
@@ -24,7 +24,7 @@ class StarSystem:
     position: Vector
     spectral_class: str = None
 
-    def distance(self, other: 'StarSystem') -> float:
+    def distance(self, other: "StarSystem") -> float:
         """
         Finds the distance between this star system and another, in light years.
 

--- a/src/packages/graceful_errors/graceful_errors.py
+++ b/src/packages/graceful_errors/graceful_errors.py
@@ -34,7 +34,7 @@ BY_ERROR: Dict[type(Exception), str] = {
 
 }
 
-CHEESES = ['Cheddar', 'Gouda', "Mozzerella", "Asiago", "Monterey Jack", "Brie", "Roquefort", "Edam"]
+CHEESES = ["Cheddar", "Gouda", "Mozzerella", "Asiago", "Monterey Jack", "Brie", "Roquefort", "Edam"]
 
 
 def make_graceful(ex: Exception, ex_uuid: UUID) -> str:

--- a/src/packages/mark_for_deletion/mark_for_deletion.py
+++ b/src/packages/mark_for_deletion/mark_for_deletion.py
@@ -35,7 +35,7 @@ class MarkForDeletion:
         self._reason = reason
         self._hash = None
 
-    def __eq__(self, other: 'MarkForDeletion') -> bool:
+    def __eq__(self, other: "MarkForDeletion") -> bool:
         if not isinstance(other, MarkForDeletion):
             return NotImplemented
 

--- a/src/packages/permissions/permissions.py
+++ b/src/packages/permissions/permissions.py
@@ -131,17 +131,17 @@ class Permission:
             Permission: initialized permission object
 
         Examples:
-            >>> permission = Permission.from_dict({'vhosts': ['recruits.fuelrats.com'], 'level': 0})
+            >>> permission = Permission.from_dict({"vhosts": ["recruits.fuelrats.com"], "level": 0})
             >>> permission.vhosts
-            {'recruits.fuelrats.com'}
+            {"recruits.fuelrats.com"}
             >>> permission.level
             0
         """
         if not isinstance(data, dict):
             raise TypeError(f"expected dict got {type(data)}")
 
-        vhosts = set(data['vhosts'])
-        level = data['level']
+        vhosts = set(data["vhosts"])
+        level = data["level"]
 
         return cls(level=level, vhosts=vhosts)
 
@@ -171,22 +171,22 @@ class Permission:
 
         self._denied_message = value
 
-    def __eq__(self, other: 'Permission') -> bool:
+    def __eq__(self, other: "Permission") -> bool:
         return self.level == other.level
 
-    def __ne__(self, other: 'Permission') -> bool:
+    def __ne__(self, other: "Permission") -> bool:
         return self.level != other.level
 
-    def __le__(self, other: 'Permission') -> bool:
+    def __le__(self, other: "Permission") -> bool:
         return self.level <= other.level
 
-    def __lt__(self, other: 'Permission') -> bool:
+    def __lt__(self, other: "Permission") -> bool:
         return self.level < other.level
 
-    def __ge__(self, other: 'Permission') -> bool:
+    def __ge__(self, other: "Permission") -> bool:
         return self.level >= other.level
 
-    def __gt__(self, other: 'Permission') -> bool:
+    def __gt__(self, other: "Permission") -> bool:
         return self.level > other.level
 
     def __hash__(self):
@@ -196,21 +196,21 @@ class Permission:
 # mapping between vhosts and permissions
 _by_vhost: Dict[str, Permission] = {}
 
-_PERMISSIONS_DICT = config['permissions']
+_PERMISSIONS_DICT = config["permissions"]
 # the uninitiated
-RECRUIT = Permission.from_dict(_PERMISSIONS_DICT['recruit'])
+RECRUIT = Permission.from_dict(_PERMISSIONS_DICT["recruit"])
 
 # the run of the mill
-RAT = Permission(1, _PERMISSIONS_DICT['rat'])
+RAT = Permission(1, _PERMISSIONS_DICT["rat"])
 
 # the overseers of the mad house
-OVERSEER = Permission.from_dict(_PERMISSIONS_DICT['overseer'])
+OVERSEER = Permission.from_dict(_PERMISSIONS_DICT["overseer"])
 
 # The rats that provide all the shiny toys
-TECHRAT = Permission.from_dict(_PERMISSIONS_DICT['techrat'])
+TECHRAT = Permission.from_dict(_PERMISSIONS_DICT["techrat"])
 
 # The Administrator.
-ADMIN = Permission.from_dict(_PERMISSIONS_DICT['administrator'])
+ADMIN = Permission.from_dict(_PERMISSIONS_DICT["administrator"])
 
 
 def require_permission(permission: Permission,

--- a/src/packages/rat/rat.py
+++ b/src/packages/rat/rat.py
@@ -59,7 +59,7 @@ class Rat:
             # don't register duplicates
             RatCache().by_uuid[uuid] = self
 
-    def __eq__(self, other: 'Rat') -> bool:
+    def __eq__(self, other: "Rat") -> bool:
         """
         Compare two Rats objects for equality
 

--- a/src/packages/ratmama/ratmama_parser.py
+++ b/src/packages/ratmama/ratmama_parser.py
@@ -157,14 +157,14 @@ async def handle_ratsignal(ctx: Context) -> None:
             return
 
     sep: Optional[str] = None
-    if ',' in message:
-        sep = ','
-    elif ';' in message:
-        sep = ';'
-    elif '|' in message:
-        sep = '|'
-    elif '-' in message:
-        sep = '-'
+    if "," in message:
+        sep = ","
+    elif ";" in message:
+        sep = ";"
+    elif "|" in message:
+        sep = "|"
+    elif "-" in message:
+        sep = "-"
 
     if not sep:
         ctx.bot.board.append(Rescue(irc_nickname=ctx.user.nickname, client=ctx.user.nickname))

--- a/src/packages/rescue/rat_rescue.py
+++ b/src/packages/rescue/rat_rescue.py
@@ -41,7 +41,7 @@ class Rescue:  # pylint: disable=too-many-public-methods
                  client: Optional[str] = None,
                  system: Optional[str] = None,
                  irc_nickname: Optional[str] = None,
-                 board: 'RatBoard' = None,
+                 board: "RatBoard" = None,
                  created_at: Optional[datetime] = None,
                  updated_at: Optional[datetime] = None,
                  unidentified_rats: Optional[List[str]] = None,
@@ -89,7 +89,7 @@ class Rescue:  # pylint: disable=too-many-public-methods
             platform(Platforms): Platform for rescue
         """
         self._platform: Platforms = platform
-        self.rat_board: 'RatBoard' = board
+        self.rat_board: "RatBoard" = board
         self._rats = rats if rats else []
         self._created_at: datetime = created_at if created_at else datetime.utcnow()
         self._updated_at: datetime = updated_at if updated_at else datetime.utcnow()

--- a/src/packages/user/user.py
+++ b/src/packages/user/user.py
@@ -134,7 +134,7 @@ class User:
         return self._nickname
 
     @classmethod
-    async def from_pydle(cls, bot: BasicClient, nickname: str) -> Optional['User']:
+    async def from_pydle(cls, bot: BasicClient, nickname: str) -> Optional["User"]:
         """
         Returns a user object from pydle's backend
 

--- a/src/packages/utils/autocorrect.py
+++ b/src/packages/utils/autocorrect.py
@@ -28,7 +28,7 @@ def correct_system_name(system: str) -> str:
     system = system.upper()
     match_regex = re.compile(r"(.*)\b([A-Z01258]{2}-[A-Z01258])\s+"
                              r"([A-Z01258])\s*([0-9OIZSB]+(-[0-9OIZSB]+)?)\b")
-    replacements = {k: v for k, v in zip('01258', 'OIZSB')}
+    replacements = {k: v for k, v in zip("01258", "OIZSB")}
 
     # Check to see if the provided system name follows the procedural format.
     matched = match_regex.match(system)

--- a/src/packages/utils/ratlib.py
+++ b/src/packages/utils/ratlib.py
@@ -21,7 +21,7 @@ from uuid import UUID
 
 import humanfriendly
 
-STRIPPED_CHARS = '\t'
+STRIPPED_CHARS = "\t"
 
 
 class Platforms(Enum):
@@ -48,22 +48,22 @@ class Colors(Enum):
     Contains mIRC-style color codes (the standard)
     Reference: https://www.mirc.com/colors.html
     """
-    WHITE = '00'
-    BLACK = '01'
-    BLUE = '02'
-    GREEN = '03'
-    RED = '04'
-    BROWN = '05'
-    PURPLE = '06'
-    ORANGE = '07'
-    YELLOW = '08'
-    LIGHT_GREEN = '09'
-    CYAN = '10'
-    LIGHT_CYAN = '11'
-    LIGHT_BLUE = '12'
-    PINK = '13'
-    GREY = '14'
-    LIGHT_GREY = '15'
+    WHITE = "00"
+    BLACK = "01"
+    BLUE = "02"
+    GREEN = "03"
+    RED = "04"
+    BROWN = "05"
+    PURPLE = "06"
+    ORANGE = "07"
+    YELLOW = "08"
+    LIGHT_GREEN = "09"
+    CYAN = "10"
+    LIGHT_CYAN = "11"
+    LIGHT_BLUE = "12"
+    PINK = "13"
+    GREY = "14"
+    LIGHT_GREY = "15"
 
 
 class Formatting(Enum):
@@ -71,12 +71,12 @@ class Formatting(Enum):
     mIRC-style formatting codes, works with colors
     """
     # this code needs to be suffixed to the colors above to actually display a color
-    FORMAT_COLOR = '\x03'
-    FORMAT_BOLD = '\x02'
-    FORMAT_UNDERLINE = '\x1F'
-    FORMAT_ITALIC = '\x1D'
-    FORMAT_REVERSE = '\x16'
-    FORMAT_RESET = '\x0F'
+    FORMAT_COLOR = "\x03"
+    FORMAT_BOLD = "\x02"
+    FORMAT_UNDERLINE = "\x1F"
+    FORMAT_ITALIC = "\x1D"
+    FORMAT_REVERSE = "\x16"
+    FORMAT_RESET = "\x0F"
 
 
 class Singleton:
@@ -128,14 +128,14 @@ def sanitize(message: str) -> str:
                                     r"(\x03([0-9]{1,2}(,[0-9]{1,2})?)?)|"
                                     r"(\x04([0-9a-fA-F]{6}(,[0-9a-fA-F]{6})?)?))"
                                     )
-    sanitized_string = control_code_regex.sub('', sanitized_string)
+    sanitized_string = control_code_regex.sub("", sanitized_string)
 
     # Remove stripped characters. (e.g. Tabs)
     for character in sanitized_string:
         if character in STRIPPED_CHARS:
-            sanitized_string = sanitized_string.replace(character, '')
+            sanitized_string = sanitized_string.replace(character, "")
 
-    sanitized_string = ' '.join(sanitized_string.split())
+    sanitized_string = " ".join(sanitized_string.split())
 
     return sanitized_string
 
@@ -211,10 +211,10 @@ def color(text: str, text_color: Colors, bg_color: Optional[Colors] = None) -> s
     if not isinstance(text_color, Colors):
         raise TypeError("Expected a Colors enum, got {type(text_color)}")
     if isinstance(bg_color, Colors):
-        return f'{Formatting.FORMAT_COLOR.value}{text_color},{bg_color}{text}' \
-            f'{Formatting.FORMAT_COLOR.value}'
+        return f"{Formatting.FORMAT_COLOR.value}{text_color},{bg_color}{text}" \
+            f"{Formatting.FORMAT_COLOR.value}"
 
-    return f'{Formatting.FORMAT_COLOR.value}{text_color}{text}{Formatting.FORMAT_COLOR.value}'
+    return f"{Formatting.FORMAT_COLOR.value}{text_color}{text}{Formatting.FORMAT_COLOR.value}"
 
 
 def bold(text: str) -> str:
@@ -228,7 +228,7 @@ def bold(text: str) -> str:
         str: the bolded text
 
     """
-    return f'{Formatting.FORMAT_BOLD.value}{text}{Formatting.FORMAT_BOLD.value}'
+    return f"{Formatting.FORMAT_BOLD.value}{text}{Formatting.FORMAT_BOLD.value}"
 
 
 def italic(text: str) -> str:
@@ -241,7 +241,7 @@ def italic(text: str) -> str:
     Returns:
         str: the italicized text
     """
-    return f'{Formatting.FORMAT_ITALIC.value}{text}{Formatting.FORMAT_ITALIC.value}'
+    return f"{Formatting.FORMAT_ITALIC.value}{text}{Formatting.FORMAT_ITALIC.value}"
 
 
 def underline(text: str) -> str:
@@ -255,7 +255,7 @@ def underline(text: str) -> str:
         str: the underlined text
 
     """
-    return f'{Formatting.FORMAT_UNDERLINE.value}{text}{Formatting.FORMAT_UNDERLINE.value}'
+    return f"{Formatting.FORMAT_UNDERLINE.value}{text}{Formatting.FORMAT_UNDERLINE.value}"
 
 
 def reverse(text: str) -> str:
@@ -269,7 +269,7 @@ def reverse(text: str) -> str:
         str: the reversed text
 
     """
-    return f'{Formatting.FORMAT_REVERSE.value}{text}{Formatting.FORMAT_REVERSE.value}'
+    return f"{Formatting.FORMAT_REVERSE.value}{text}{Formatting.FORMAT_REVERSE.value}"
 
 
 @dataclass(frozen=True)
@@ -290,7 +290,7 @@ class Vector:
 
         return sqrt(self.x ** 2 + self.y ** 2 + self.z ** 2)
 
-    def normal(self) -> 'Vector':
+    def normal(self) -> "Vector":
         """
         The normalized vector, representing 1 "unit" of distance in the Vector's
         original direction.
@@ -305,7 +305,7 @@ class Vector:
 
         mag = self.magnitude()
         if mag == 0:
-            raise ValueError('Cannot normalize a zero Vector.')
+            raise ValueError("Cannot normalize a zero Vector.")
         return Vector(self.x / mag, self.y / mag, self.z / mag)
 
     def distance(self, other) -> float:
@@ -319,7 +319,7 @@ class Vector:
             ((other.z - self.z) ** 2))
 
     @classmethod
-    def zero(cls) -> 'Vector':
+    def zero(cls) -> "Vector":
         """
         Returns the zero Vector.
         """


### PR DESCRIPTION
This package adds the ability to lint our project against our string quotations. Given that python can use either single or double quotes interchangeably, it's up to us to standardize it.

Per @theunkn0wn1's suggestion, I've made it enforce double quotes for everything. This does not, however, apply to string interpolation. Within interpolated values, single quotes are allowed.

e.g. `"this is a {'fancy' if fancy else 'boring'} string"`