### PR TITLE
parallelize build system 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,7 +184,6 @@ workflows:
       - tests:
           #          don't bother running tests if linting catches any errors
           requires:
-            - linting
             - setup_workspace
 
 notify:


### PR DESCRIPTION
Will decrease CI build time, and allow the test suite to run even if pylint throws a fit.
This way, developers can get more productive feedback - the state of the test run - even if it fails linting