### PR TITLE
[SPARK-110] Pull request labels

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,7 +159,7 @@ Bad:  ``[Suggestion|Kudos] This is great, but...``
 Labels may be applied to your pull requests, for the purposes of organization and / or overall 
 status.
 
-| label | Explanation |
+|       label       |                         Explanation                          |
 | ----------------- | ------------------------------------------------------------ |
 Awaiting changes    | is on hold until requested changes have been effected
 Bug Fix             | fixes some bug

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,15 +162,15 @@ status.
 | label | Explanation |
 | ----------------- | ------------------------------------------------------------ |
 Awaiting changes    | is on hold until requested changes have been effected
-Feature             | adds a new feature
 Bug Fix             | fixes some bug
-Refactor            | refactors something
-Documentation       | only effects documentation
-Linting             | adjusts the linting configurations
 CI change           | reconfigures the CI environment
-Dependency change   | modifies the dependencies
-Policy change       | modifies the contributing policies
 Consensus required  | requires the consensus of all core contributors
+Dependency change   | modifies the dependencies
+Documentation       | only effects documentation
+Feature             | adds a new feature
+Refactor            | refactors something
+Linting             | adjusts the linting configurations
+Policy change       | modifies the contributing policies
 
 ## Testing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,6 +148,13 @@ During a peer review, reviewers will add a tag to the comment to help the author
 [Kudos]|The reviewer liked this, specifically. Go you.
 [Suggestion]| An optional, alternative approach.
 
+Adding multiple tags to a comment is fine.  Do not combine tags.
+
+Good: ``[Suggestion][Kudos] This is great, but...``
+
+Bad:  ``[Suggestion|Kudos] This is great, but...``
+
+
 ## Pull request labels
 Labels may be applied to your pull requests, for the purposes of organization and / or overall 
 status.
@@ -164,14 +171,6 @@ CI change           | This pull request reconfigures the CI environment
 Dependency change   | this pull request modifies our dependencies
 Policy              | this pull request modifies our contributing policies
 Consensus required  | this pull request requires the consensus of all core contributors
-
-
-
-Adding multiple tags to a comment is fine.  Do not combine tags.
-
-Good: ``[Suggestion][Kudos] This is great, but...``
-
-Bad:  ``[Suggestion|Kudos] This is great, but...``
 
 ## Testing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,17 +160,17 @@ Labels may be applied to your pull requests, for the purposes of organization an
 status.
 
 | label | Explanation |
-| --- | --- |
-Awaiting changes    | this pull request is on hold until requested changes have been effected
-Feature             | this pull request adds a new feature
-Bug Fix             | this pull request fixes some bug
-Refactor            | this pull request refactors something
-Documentation       | this pull request only effects documentation
-Linting             | this pull request adjusts our linting configurations
-CI change           | This pull request reconfigures the CI environment
-Dependency change   | this pull request modifies our dependencies
-Policy              | this pull request modifies our contributing policies
-Consensus required  | this pull request requires the consensus of all core contributors
+| ----------------- | ------------------------------------------------------------ |
+Awaiting changes    | is on hold until requested changes have been effected
+Feature             | adds a new feature
+Bug Fix             | fixes some bug
+Refactor            | refactors something
+Documentation       | only effects documentation
+Linting             | adjusts the linting configurations
+CI change           | reconfigures the CI environment
+Dependency change   | modifies the dependencies
+Policy change       | modifies the contributing policies
+Consensus required  | requires the consensus of all core contributors
 
 ## Testing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,17 +159,17 @@ Bad:  ``[Suggestion|Kudos] This is great, but...``
 Labels may be applied to your pull requests, for the purposes of organization and / or overall 
 status.
 
-|       label       |                         Explanation                          |
+|       Label       |                         Explanation                          |
 | ----------------- | ------------------------------------------------------------ |
-Awaiting changes    | On hold until requested changes have been effected
+Awaiting changes    | On hold until requested changes have been applied
 Bug Fix             | Fixes a bug
-CI change           | Modifies the configuration of Continuous Integration
-Dependency change   | Modifies the dependencies
-Documentation       | Only effects documentation
+CI change           | Modifies the configuration of Continuous Integration (CI)
+Dependency change   | Changes the project's dependencies
+Documentation       | Modifies project documentation
 Feature             | Adds a new feature
-Refactor            | Refactors something
-Linting             | Adjusts the linting configurations
-Policy change       | Modifies the contributing policies
+Refactor            | Refactors an existing system
+Linting             | Adjusts the linting rules
+Policy change       | Modifies contributing or development policies
 Team decision       | Requires the consensus of all core contributors
 
 ## Testing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,22 +155,22 @@ Good: ``[Suggestion][Kudos] This is great, but...``
 Bad:  ``[Suggestion|Kudos] This is great, but...``
 
 
-## Pull request labels
+## Pull Request Labels
 Labels may be applied to your pull requests, for the purposes of organization and / or overall 
 status.
 
 |       label       |                         Explanation                          |
 | ----------------- | ------------------------------------------------------------ |
-Awaiting changes    | is on hold until requested changes have been effected
-Bug Fix             | fixes some bug
-CI change           | reconfigures the CI environment
-Consensus required  | requires the consensus of all core contributors
-Dependency change   | modifies the dependencies
-Documentation       | only effects documentation
-Feature             | adds a new feature
-Refactor            | refactors something
-Linting             | adjusts the linting configurations
-Policy change       | modifies the contributing policies
+Awaiting changes    | On hold until requested changes have been effected
+Bug Fix             | Fixes a bug
+CI change           | Modifies the configuration of Continuous Integration
+Dependency change   | Modifies the dependencies
+Documentation       | Only effects documentation
+Feature             | Adds a new feature
+Refactor            | Refactors something
+Linting             | Adjusts the linting configurations
+Policy change       | Modifies the contributing policies
+Team decision       | Requires the consensus of all core contributors
 
 ## Testing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,6 +148,23 @@ During a peer review, reviewers will add a tag to the comment to help the author
 [Kudos]|The reviewer liked this, specifically. Go you.
 [Suggestion]| An optional, alternative approach.
 
+## Pull request labels
+Labels may be applied to your pull requests, for the purposes of organization and / or overall 
+status.
+
+| label | Explanation |
+| --- | --- |
+Awaiting changes    | this pull request is on hold until requested changes have been effected
+Feature             | this pull request adds a new feature
+Bug Fix             | this pull request fixes some bug
+Refactor            | this pull request refactors something
+Documentation       | this pull request only effects documentation
+Linting             | this pull request adjusts our linting configurations
+CI change           | This pull request reconfigures the CI environment
+Dependency change   | this pull request modifies our dependencies
+Policy              | this pull request modifies our contributing policies
+Consensus required  | this pull request requires the consensus of all core contributors
+
 
 
 Adding multiple tags to a comment is fine.  Do not combine tags.


### PR DESCRIPTION
This PR proposes a set of labels that can be applied to pull requests.

The function of the labels is to complement our PR review tags, providing a high-level status of a given pull request.

For instance, a reviewer may append the `awaiting changes` label to a pull request as to denote, without looking at comments, that the pull request is in the submitter's hand.

This pull request also proposes labels denoting the *kind* of pull request it is. For instance, this pull request would fall under `documentation`, as it changes documentation;
`policy`, as it changes policy;
 and `consensus required`, as policy changes require a consensus.

