### PR TITLE
[SPARK-122] Adjust Galaxy's search parameters to use API indexes

### DIFF
--- a/tests/galaxy/galaxy_fx.py
+++ b/tests/galaxy/galaxy_fx.py
@@ -55,11 +55,11 @@ def mock_system_api_server_fx():
 
         # Star Data
         # - Fuelum
-        httpserver.expect_request("/api/stars", query_string=b"filter%5BsystemId64:eq%5D=5031721931482&filter%5BisMainStar:eq%5D=1").respond_with_data(
-            """{"data":[{"id":"3206960","attributes":{"id64":36033828740895450,"name":"Fuelum","subType":"K (Yellow-Orange) Star","isMainStar":true}}],"meta":{"results":{"available":1}}}"""
+        httpserver.expect_request("/api/stars", query_string=b"filter%5BsystemId:eq%5D=1464").respond_with_data(
+            """{"data":[{"id":"3202571","attributes":{"id64":72062625759859420,"name":"NN 4230 B","subType":"M (Red dwarf) Star","isMainStar":false}},{"id":"3206960","attributes":{"id64":36033828740895450,"name":"Fuelum","subType":"K (Yellow-Orange) Star","isMainStar":true}}],"meta":{"results":{"available":1}}}"""
         )
         # - Angrbonii
-        httpserver.expect_request("/api/stars", query_string=b"filter%5BsystemId64:eq%5D=40557912804216&filter%5BisMainStar:eq%5D=1").respond_with_data(
+        httpserver.expect_request("/api/stars", query_string=b"filter%5BsystemId:eq%5D=6337").respond_with_data(
             """{"data":[{"id":"377822","attributes":{"id64":72098151950732160,"name":"Angrbonii A","subType":"L (Brown dwarf) Star","isMainStar":true}}],"meta":{"results":{"available":1}}}"""
         )
         # - Fallthrough for failed searches


### PR DESCRIPTION
Galaxy was performing searches for system main stars by using the `systemId64` and `isMainStar` properties, which are not indexed. This caused slow and inefficient searches for the API.

This changes the search to use the `systemId` property, which is properly indexed. It also adjusts the code to find the Main star by itself, which should be relatively lightweight.