### PR TITLE
[SPARK-124] Add a retry handler to Galaxy's _call

### DIFF
--- a/src/packages/galaxy/galaxy.py
+++ b/src/packages/galaxy/galaxy.py
@@ -15,7 +15,7 @@ from html import escape
 import json
 from typing import Dict, List, Optional, Tuple
 
-from aiohttp import ClientError, ClientSession, ClientTimeout
+import aiohttp
 
 from config import config
 from ..utils import Vector
@@ -64,7 +64,7 @@ class Galaxy:
     MAX_RETRIES = 3
     "The maximum number of times to retry a failed HTTP request before failing permanently."
 
-    TIMEOUT = ClientTimeout(total=10)
+    TIMEOUT = aiohttp.ClientTimeout(total=10)
     "A ClientTimeout object representing the total time an HTTP request can take before failing."
 
     RETRY_SLEEP = 1
@@ -302,11 +302,11 @@ class Galaxy:
         url = f"{base_url}{endpoint}?{param_string}"
         for retry in range(self.MAX_RETRIES):
             try:
-                async with ClientSession(raise_for_status=True,
-                                         timeout=self.TIMEOUT) as session:
+                async with aiohttp.ClientSession(raise_for_status=True,
+                                                 timeout=self.TIMEOUT) as session:
                     async with session.get(url) as response:
                         return json.loads(await response.text())
-            except ClientError:
+            except aiohttp.ClientError:
                 # If we've used our last retry, re-raise the offending exception.
                 if retry == (self.MAX_RETRIES - 1):
                     raise

--- a/src/packages/galaxy/galaxy.py
+++ b/src/packages/galaxy/galaxy.py
@@ -292,14 +292,13 @@ class Galaxy:
                 [f"{key}={escape(str(value))}" for key, value in params.items()]
             )
         url = f"{base_url}{endpoint}?{param_string}"
-        retry_count = 0
-        while True:
+        for retry in range(self.MAX_RETRIES):
             try:
                 async with ClientSession(raise_for_status=True,
                                          timeout=self.TIMEOUT) as session:
                     async with session.get(url) as response:
                         return json.loads(await response.text())
             except ClientError:
-                retry_count += 1
-                if retry_count > self.MAX_RETRIES:
+                # If we've used our last retry, re-raise the offending exception.
+                if retry == (self.MAX_RETRIES - 1):
                     raise

--- a/src/packages/galaxy/galaxy.py
+++ b/src/packages/galaxy/galaxy.py
@@ -10,6 +10,7 @@ Licensed under the BSD 3-Clause License.
 See LICENSE.md
 """
 
+import asyncio
 from html import escape
 import json
 from typing import Dict, List, Optional, Tuple
@@ -59,8 +60,15 @@ class Galaxy:
         )
     }
     MAX_PLOT_DISTANCE = 20000
+
     MAX_RETRIES = 3
+    "The maximum number of times to retry a failed HTTP request before failing permanently."
+
     TIMEOUT = ClientTimeout(total=10)
+    "A ClientTimeout object representing the total time an HTTP request can take before failing."
+
+    RETRY_SLEEP = 1
+    "The amount of time, in seconds, to wait between HTTP retries."
 
     def __init__(self, url: str = None):
         self.url = url or config['api']['url']
@@ -302,3 +310,6 @@ class Galaxy:
                 # If we've used our last retry, re-raise the offending exception.
                 if retry == (self.MAX_RETRIES - 1):
                     raise
+
+                # Introduce a short pause between retries
+                await asyncio.sleep(self.RETRY_SLEEP)

--- a/tests/fixtures/galaxy_fx.py
+++ b/tests/fixtures/galaxy_fx.py
@@ -110,12 +110,4 @@ def galaxy_fx(mock_system_api_server_fx) -> Galaxy: # pylint: disable=redefined-
     Test fixture for Galaxy. Includes a mock API server with pre-made calls.
     """
 
-    fixture = Galaxy(mock_system_api_server_fx.url_for("/"))
-
-    # Remove the sleep timer for retries for the purposes of testing.
-    async def delay_stub(_retry) -> None:
-        pass
-
-    fixture._retry_delay = delay_stub
-
-    return fixture
+    return Galaxy(mock_system_api_server_fx.url_for("/"))

--- a/tests/fixtures/galaxy_fx.py
+++ b/tests/fixtures/galaxy_fx.py
@@ -95,6 +95,12 @@ def mock_system_api_server_fx():
             """{"data":[]}"""
         )
 
+        # Tests that Galaxy will retry failed requests
+        httpserver.expect_oneshot_request("/badendpoint").respond_with_data(status = 400)
+        httpserver.expect_oneshot_request("/badendpoint").respond_with_data(status = 500)
+        httpserver.expect_oneshot_request("/badendpoint").respond_with_data("""{"success":true}""")
+        httpserver.expect_request("/reallybadendpoint").respond_with_data(status = 404)
+
         yield httpserver
 
 

--- a/tests/fixtures/galaxy_fx.py
+++ b/tests/fixtures/galaxy_fx.py
@@ -111,6 +111,11 @@ def galaxy_fx(mock_system_api_server_fx) -> Galaxy: # pylint: disable=redefined-
     """
 
     fixture = Galaxy(mock_system_api_server_fx.url_for("/"))
+
     # Remove the sleep timer for retries for the purposes of testing.
-    fixture.RETRY_SLEEP = 0
+    async def delay_stub(_retry) -> None:
+        pass
+
+    fixture._retry_delay = delay_stub
+
     return fixture

--- a/tests/fixtures/galaxy_fx.py
+++ b/tests/fixtures/galaxy_fx.py
@@ -110,4 +110,7 @@ def galaxy_fx(mock_system_api_server_fx) -> Galaxy: # pylint: disable=redefined-
     Test fixture for Galaxy. Includes a mock API server with pre-made calls.
     """
 
-    return Galaxy(mock_system_api_server_fx.url_for("/"))
+    fixture = Galaxy(mock_system_api_server_fx.url_for("/"))
+    # Remove the sleep timer for retries for the purposes of testing.
+    fixture.RETRY_SLEEP = 0
+    return fixture

--- a/tests/unit/test_galaxy.py
+++ b/tests/unit/test_galaxy.py
@@ -11,6 +11,8 @@ See LICENSE
 
 import pytest
 
+from aiohttp import ClientError
+
 pytestmark = [pytest.mark.unit, pytest.mark.galaxy]
 
 
@@ -120,3 +122,21 @@ async def test_plot_waypoint_route_invalid(galaxy_fx):
     """
     with pytest.raises(ValueError):
         await galaxy_fx.plot_waypoint_route("Fuelum", "Fualun")
+
+@pytest.mark.asyncio
+async def test_http_retry_eventually(galaxy_fx):
+    """
+    Test that Galaxy will retry a failed request a number of times before failing.
+    Ensures that an eventually-good endpoint will return data.
+    """
+    data = await galaxy_fx._call("badendpoint")
+    assert data['success']
+
+@pytest.mark.asyncio
+async def test_http_retry_permanent(galaxy_fx):
+    """
+    Test that Galaxy has a limit to number of retries before it will outright
+    fail.
+    """
+    with pytest.raises(ClientError):
+        await galaxy_fx._call("reallybadendpoint")


### PR DESCRIPTION
The Internet is a weird and mysterious place. Things fail. Servers fall over. Sometimes these failures are brief. Sometimes they only last a second or two.

This PR gives Galaxy the ability to retry a failed API call (timeout, 404, 500, etc.) up to three times before it will consider it a permanent failure and raise the red flag.