### PR TITLE
User Dataclass

### DIFF
--- a/src/packages/user/user.py
+++ b/src/packages/user/user.py
@@ -10,20 +10,47 @@ Licensed under the BSD 3-Clause License.
 
 See LICENSE.md
 """
-from functools import reduce
-from operator import xor
+from __future__ import annotations  # enable forward-references
+
+from dataclasses import dataclass
 from typing import Union, Optional
 
 from pydle import BasicClient
 
 
+@dataclass(frozen=True)
 class User:
-    """
-    Represents an IRC user
-    """
+    away: bool
+    away_message: Optional[str]
+    username: str
+    hostname: str
+    realname: str
+    identified: bool
+    account: Optional[str]
+    nickname: str
 
     @classmethod
-    def process_vhost(cls, vhost: Union[str, None]) -> Union[None, str]:
+    async def from_pydle(cls, bot: BasicClient, nickname: str) -> Optional[User]:
+        """
+        Returns a user object from pydle's backend
+
+        Args:
+            bot (BasicClient): Mechaclient instance
+            nickname (str): nickname of user
+
+        Returns:
+            User: found user
+            None: user not found
+        """
+        # fetch the user object from pydle
+        data = bot.users.get(nickname.casefold(), None)
+
+        # if we got a object back
+        if data:
+            return cls(**data)
+
+    @classmethod
+    def process_vhost(cls, vhost: Union[str, None]) -> Optional[str]:
         """
         Refines a raw vhost into `{role}.fuelrats.com`
 
@@ -49,142 +76,3 @@ class User:
 
         # return the corresponding vhost
         return f"{host}.fuelrats.com"
-
-    def __init__(self,
-                 away: bool,
-                 away_message: Optional[str],
-                 identified: bool,
-                 account: str,
-                 nickname: str,
-                 # attributes below this line are nullable
-                 username: Optional[str] = None,
-                 hostname: Optional[str] = None,
-                 realname: Optional[str] = None,
-
-                 ):
-        """
-        Creates a new IRC user object
-        Args:
-            idle (int): time user is idle for
-            away (bool): user's away flag
-            away_message (str): user's away message
-            username (str): username
-            hostname (str): hostname
-            realname (str): realname
-            identified (bool): NS identification flag
-            account (str): NS identity
-            nickname (str): IRC nickname of user
-
-        As a whois entry will not return some fields for users that don't exist,
-        Username, hostname, realname, server, and server_info are nullable.
-
-        """
-        self._away: bool = away
-        self._away_message: str = away_message
-        self._username: str = username
-        self._hostname: str = self.process_vhost(hostname)
-        self._realname: str = realname
-        self._identified: bool = identified
-
-        self._account: str = account
-        self._nickname: str = nickname
-
-        self._hash = None
-
-    @property
-    def away(self) -> bool:
-        """User's away flag"""
-        return self._away
-
-    @property
-    def away_message(self) -> Union[None, str]:
-        """
-        User's away message, if it exists. otherwise None
-        """
-        return self._away_message
-
-    @property
-    def username(self) -> str:
-        """Username"""
-        return self._username
-
-    @property
-    def hostname(self) -> str:
-        """Hostname"""
-        return self._hostname
-
-    @property
-    def realname(self) -> str:
-        """User's set realname"""
-        return self._realname
-
-    @property
-    def identified(self) -> bool:
-        """Nickserv ident flag"""
-        return self._identified
-
-    @property
-    def account(self) -> Union[str, None]:
-        """Nickserv account, if applicable"""
-        return self._account
-
-    @property
-    def nickname(self) -> str:
-        """Nickname"""
-        return self._nickname
-
-    @classmethod
-    async def from_pydle(cls, bot: BasicClient, nickname: str) -> Optional['User']:
-        """
-        Returns a user object from pydle's backend
-
-        Args:
-            bot (BasicClient): Mechaclient instance
-            nickname (str): nickname of user
-
-        Returns:
-            User: found user
-            None: user not found
-        """
-        # fetch the user object from
-        data = bot.users.get(nickname.casefold(), None)
-
-        # if we got a object back
-
-        if data:
-            return cls(**data)
-
-    def __eq__(self, other) -> bool:
-        """
-        Check equality
-
-        Args:
-            other (User):
-
-        Returns:
-            bool
-        """
-        if not isinstance(other, User):
-            return NotImplemented
-
-        conditions = [
-
-            self.away == other.away,
-            self.away_message == other.away_message,
-            self.username == other.username,
-            self.hostname == other.hostname,
-            self.identified == other.identified,
-            self.account == other.account,
-            self.nickname == other.nickname
-        ]
-        return all(conditions)
-
-    def __hash__(self) -> int:
-        if self._hash is None:
-            attrs = (self.away, self.away_message, self.username,
-                     self.hostname, self.identified,
-                     self.account, self.nickname)
-
-            # borrowed hashing mechanism from the old Trigger object
-            self._hash = reduce(xor, map(hash, attrs))
-        return self._hash

--- a/src/packages/user/user.py
+++ b/src/packages/user/user.py
@@ -20,6 +20,9 @@ from pydle import BasicClient
 
 @dataclass(frozen=True)
 class User:
+    """
+    Represents an IRC user
+    """
     away: bool
     away_message: Optional[str]
     username: str


### PR DESCRIPTION
The `User` object happens to be a prime target for dataclass conversion

1. Its read-only, once an object is created it doesn't get modified at runtime.
 - its event scoped, disappearing as its containing context falls out of scope
2. As it is read only, its hashable
 - dataclass implements this for us, simplifying logic
3. Dataclass implements equality operations for us, simplifying logic
4. Doesn't have any advanced getter/setter logic

Bottom line, by converting `User` to a dataclass a bunch of magics get implemented for us, while greatly reducing testing requirements.
