### PR TITLE
Refactored `..context._split_message` to be less hacky

### DIFF
--- a/src/packages/context/context.py
+++ b/src/packages/context/context.py
@@ -176,18 +176,10 @@ def _split_message(string: str) -> Tuple[List[str], List[str]]:
         >>> _split_message("pink fluffy unicorns")
         (['pink', 'fluffy', 'unicorns'], ['pink fluffy unicorns', 'fluffy unicorns', 'unicorns'])
     """
-    words = []
-    words_eol = []
-    remaining = string
-    while True:
-        words_eol.append(remaining)
-        try:
-            word, remaining = remaining.split(maxsplit=1)
-        except ValueError:
-            # we couldn't split -> only one word left
-            words.append(remaining)
-            break
-        else:
-            words.append(word)
+    # get the words
+    words = string.split()
+
+    # reconstruct the original phrase EOL style, through clever usage of slice
+    words_eol = [" ".join(words[i:]) for i, _ in enumerate(words)]
 
     return words, words_eol

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -12,7 +12,7 @@ See LICENSE.md
 """
 import pytest
 
-from src.packages.context.context import Context
+from src.packages.context.context import Context, _split_message
 
 pytestmark = [pytest.mark.unit, pytest.mark.context]
 
@@ -90,3 +90,23 @@ async def test_from_message(bot_fx, channel, user, message, words, words_eol, pr
     assert user == ctx.user.nickname
     assert words == ctx.words
     assert words_eol == ctx.words_eol
+
+
+@pytest.mark.parametrize("payload, words, words_eol",
+                         [
+                             (
+                                     "pink fluffy unicorns",
+                                     ["pink", "fluffy", "unicorns"],
+                                     ["pink fluffy unicorns", "fluffy unicorns", "unicorns"]
+                             ),
+                             (
+                                     "my       malformed    string",
+                                     ['my', 'malformed', 'string'],
+                                     ['my malformed string', 'malformed string', 'string']
+                             )
+
+                         ])
+def test_split_message(payload, words, words_eol):
+    out_words, out_eol = _split_message(payload)
+    assert out_eol == words_eol, "words EOL did not match expected output!"
+    assert out_words == words, "words did not match expected output!@"


### PR DESCRIPTION
While our existing solution works, it depends on using exceptions to control program flow.
This, coupled with a `while True` loop, is a code smell and leaves much to be desired.

turns out that entire control structure can be implemented with a well written list comprehension, greatly saving in both complexity and code smell.

**Bonus feature!!** added a dedicated test to this routine

This PR does not cause any change in end-behavior, and does not modify any existing tests.