### PR TITLE
[SPARK-148] Give Galaxy its own configuration value

### DIFF
--- a/config/config.template.toml
+++ b/config/config.template.toml
@@ -16,6 +16,9 @@ prefix = "!"
 [api]
 online_mode = false
 
+[system_api]
+url = "https://system.api.url/api"
+
 [ratsignal_parser]
 announcer_nicks = [ "ratmama[bot]",]
 

--- a/config/testing.toml
+++ b/config/testing.toml
@@ -26,6 +26,9 @@ prefix = "!"
 online_mode = false
 url = "http://localhost/"
 
+[system_api]
+url = "http://localhost/"
+
 [ratsignal_parser]
 announcer_nicks = [ "RatMama[Bot]", "some_announcer" ]
 

--- a/src/packages/galaxy/galaxy.py
+++ b/src/packages/galaxy/galaxy.py
@@ -84,7 +84,7 @@ class Galaxy:
     "A ClientTimeout object representing the total time an HTTP request can take before failing."
 
     def __init__(self, url: str = None):
-        self.url = url or self._config['api']['url']
+        self.url = url or self._config['system_api']['url']
 
     async def find_system_by_name(self, name: str) -> typing.Optional[StarSystem]:
         """


### PR DESCRIPTION
Required for #149. Galaxy is currently using a config value that was intended for the API, we need to separate the two.