### PR TITLE
Add PyTest markers to ini to silence warnings

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -14,7 +14,7 @@ markers =
     context: marks a test as a ( command )context test
     permissions: marks a test as a rat permissions test
     ratboard: marks a test as a ratboard test
-    quotations: marks a test as a quotations test
+    quotation: marks a test as a quotations test
     user: marks a test as a user object test
     logging: marks a test as being a test for logging
     ratlib: marks a test as a ratlib test
@@ -27,6 +27,8 @@ markers =
     offline: offline-aware tests
     mechaclient: mechaclient tests
     rules: command rule tests
+    fact_class: tests for the Fact class
+    fact_manager: tests for the FactManager
 testpaths = tests/integration tests/regressions tests/unit
 
 addopts = --doctest-modules


### PR DESCRIPTION
```
====================================================================== warnings summary ======================================================================
/home/eearslya/.local/share/virtualenvs/pipsqueak3--g2OKrPY/lib/python3.7/site-packages/_pytest/mark/structures.py:332
  /home/eearslya/.local/share/virtualenvs/pipsqueak3--g2OKrPY/lib/python3.7/site-packages/_pytest/mark/structures.py:332: PytestUnknownMarkWarning: Unknown pytest.mark.fact_class - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,

/home/eearslya/.local/share/virtualenvs/pipsqueak3--g2OKrPY/lib/python3.7/site-packages/_pytest/mark/structures.py:332
  /home/eearslya/.local/share/virtualenvs/pipsqueak3--g2OKrPY/lib/python3.7/site-packages/_pytest/mark/structures.py:332: PytestUnknownMarkWarning: Unknown pytest.mark.fact_manager - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,

/home/eearslya/.local/share/virtualenvs/pipsqueak3--g2OKrPY/lib/python3.7/site-packages/_pytest/mark/structures.py:332
  /home/eearslya/.local/share/virtualenvs/pipsqueak3--g2OKrPY/lib/python3.7/site-packages/_pytest/mark/structures.py:332: PytestUnknownMarkWarning: Unknown pytest.mark.quotation - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,

-- Docs: https://docs.pytest.org/en/latest/warnings.html
```

Several markers appear to have been used without adding them to pytest.ini.