### PR TITLE
[SPARK-150] Add a config option for offline-awareness

### DIFF
--- a/src/packages/offline_awareness/__init__.py
+++ b/src/packages/offline_awareness/__init__.py
@@ -13,6 +13,8 @@ Licensed under the BSD 3-Clause License.
 See LICENSE.md
 """
 
+from src.config import PLUGIN_MANAGER
+
 from ._offline_aware_abc import OfflineAwareABC
 
 # ####
@@ -38,3 +40,5 @@ __all__ = [
     "online",
     "offline"
 ]
+
+PLUGIN_MANAGER.register(OfflineAwareABC, "offline_awareness")


### PR DESCRIPTION
Use the config value `['api']['online_mode']` for offline awareness. Use the rehash handler to read the value and switch online status.