### PR TITLE
Upgrade to 3.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
     docker:
       # specify the version you desire here
       # use `-browsers` prefix for selenium tests, e.g. `3.6.1-browsers`
-      - image: circleci/python:3.7-stretch
+      - image: circleci/python:3.8-stretch
         environment:
           # set an env token to where our circleci database is
           # by default the user is `root` and the db name is `circle_test`

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
       - image: circleci/python:3.8-buster
         environment:
           # set an env token to where our circleci database is
-          # by default the user is `root` and the db name is `circle_test`
+          # by default the user is `postgres` and the db name is `circle_test`
           TEST_DATABASE_URL: postgresql://postgres:mecha@localhost/circle_test
 
       # Postgres container
@@ -100,8 +100,8 @@ jobs:
       - image: circleci/python:3.8-buster
         environment:
           # set an env token to where our circleci database is
-          # by default the user is `root` and the db name is `circle_test`
-          TEST_DATABASE_URL: postgresql://root:mecha@localhost/circle_test
+          # by default the user is `postgres` and the db name is `circle_test`
+          TEST_DATABASE_URL: postgresql://postgres:mecha@localhost/circle_test
 
       # Postgres container
       - image: circleci/postgres:11.6-alpine

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,14 +13,14 @@ jobs:
     docker:
       # specify the version you desire here
       # use `-browsers` prefix for selenium tests, e.g. `3.6.1-browsers`
-      - image: circleci/python:3.8-stretch
+      - image: circleci/python:3.8-buster
         environment:
           # set an env token to where our circleci database is
           # by default the user is `root` and the db name is `circle_test`
-          TEST_DATABASE_URL: postgresql://root:mecha@localhost/circle_test
+          TEST_DATABASE_URL: postgresql://postgres:mecha@localhost/circle_test
 
       # Postgres container
-      - image: circleci/postgres:9.6.2-alpine
+      - image: circleci/postgres:11.6-alpine
         environment:
           #          DB_USER: mecha
           #          DB_DATABASE: mecha
@@ -38,14 +38,14 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-            - v3-dependencies-{{ checksum "Pipfile.lock" }}
+            - v4-dependencies-{{ checksum "Pipfile.lock" }}
 
 
       # do caching magic
       - save_cache:
           paths:
             - ".venv"
-          key: v3-dependencies-{{ checksum "Pipfile.lock" }}
+          key: v4-dependencies-{{ checksum "Pipfile.lock" }}-{{ checksum "Pipfile"}}
 
 
       - run:
@@ -60,7 +60,7 @@ jobs:
           command: sudo apt-get update
       - run:
           name: install psql client
-          command: sudo apt-get install postgresql-client-9.6
+          command: sudo apt-get install postgresql-client-11
       - run: whoami
       # wait for the database to spin up
       - run:
@@ -97,14 +97,14 @@ jobs:
       PIPENV_VENV_IN_PROJECT: true
 
     docker:
-      - image: circleci/python:3.7-stretch
+      - image: circleci/python:3.8-buster
         environment:
           # set an env token to where our circleci database is
           # by default the user is `root` and the db name is `circle_test`
           TEST_DATABASE_URL: postgresql://root:mecha@localhost/circle_test
 
       # Postgres container
-      - image: circleci/postgres:9.6.2-alpine
+      - image: circleci/postgres:11.6-alpine
         environment:
           #          DB_USER: mecha
           #          DB_DATABASE: mecha
@@ -126,14 +126,14 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-            - v3-dependencies-{{ checksum "Pipfile.lock" }}
+            - v4-dependencies-{{ checksum "Pipfile.lock" }}-{{ checksum "Pipfile"}}
 
 
       # do caching magic
       - save_cache:
           paths:
             - ".venv"
-          key: v3-dependencies-{{ checksum "Pipfile.lock" }}
+          key: v4-dependencies-{{ checksum "Pipfile.lock" }}-{{ checksum "Pipfile"}}
 
 
       - run:
@@ -148,7 +148,7 @@ jobs:
           command: sudo apt-get update
       - run:
           name: install psql client
-          command: sudo apt-get install postgresql-client-9.6
+          command: sudo apt-get install postgresql-client-11
       - run: whoami
       # wait for the database to spin up
       - run:
@@ -177,7 +177,7 @@ jobs:
     docker:
       # specify the version you desire here
       # use `-browsers` prefix for selenium tests, e.g. `3.6.1-browsers`
-      - image: circleci/python:3.7
+      - image: circleci/python:3.8-buster
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images
@@ -191,7 +191,7 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-            - v3-dependencies-{{ checksum "Pipfile.lock" }}
+            - v4-dependencies-{{ checksum "Pipfile.lock" }}
 
 
       - run:
@@ -208,7 +208,7 @@ jobs:
       - save_cache:
           paths:
             - ".venv"
-          key: v3-dependencies-{{ checksum "Pipfile.lock" }}
+          key: v4-dependencies-{{ checksum "Pipfile.lock" }}-{{ checksum "Pipfile"}}
       # cache code and dependencies for later jobs
       - persist_to_workspace:
           root: .
@@ -224,7 +224,7 @@ jobs:
     docker:
       # specify the version you desire here
       # use `-browsers` prefix for selenium tests, e.g. `3.6.1-browsers`
-      - image: circleci/python:3.7
+      - image: circleci/python:3.8-buster
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images
@@ -238,15 +238,9 @@ jobs:
           at: .
 
       - run:
-          name: retrieve pylint-exit
-          command: curl -o pylint-exit https://raw.githubusercontent.com/theunkn0wn1/pylint-exit/master/pylint_exit.py
-      - run:
-          name: retrieve pylint-exit's dependency
-          command: pipenv run pip install bitarray
-      - run:
           name: Run pylint over project
           # run pylint, pass it through pylint-exit so Circle doesn't throw a fit
-          command: pipenv run pylint src || pipenv run python pylint-exit $?
+          command: pipenv run pylint src || pipenv run pylint-exit $?
       - run:
           name: run pycodestyle over project
           command: pipenv run pycodestyle src

--- a/Pipfile
+++ b/Pipfile
@@ -21,6 +21,7 @@ pylint = "*"
 pytest-httpserver = "*"
 codecov = "*"
 pycodestyle = "*"
+pylint-exit = ">=1.1.0"
 
 [requires]
 python_version = "3.8"

--- a/Pipfile
+++ b/Pipfile
@@ -23,4 +23,4 @@ codecov = "*"
 pycodestyle = "*"
 
 [requires]
-python_version = "3.7"
+python_version = "3.8"

--- a/config/testing.toml
+++ b/config/testing.toml
@@ -16,7 +16,7 @@ log_file = "logs/unit_tests.log"
 host = "localhost"
 port = 5432
 dbname = "circle_test"
-username = "root"
+username = "postgres"
 password = "mecha"
 
 [commands]


### PR DESCRIPTION
Update project to target 3.8, necessary for #158 

Required changes made:
- update to Buster
- update PSQL to >=11.0

Optional changes made:
use official `pylint-exit` packages [now that my custom changes have been merged upstream](https://github.com/jongracecox/pylint-exit/pull/2)