### PR TITLE
Redid Rescue.(add/remove)_rat to be more sane

### DIFF
--- a/src/packages/rat/rat.py
+++ b/src/packages/rat/rat.py
@@ -13,11 +13,12 @@ See LICENSE.md
 This module is built on top of the Pydle system.
 """
 
-from loguru import logger
 from functools import reduce
 from operator import xor
 from typing import Optional
 from uuid import UUID
+
+from loguru import logger
 
 from ..utils import Platforms
 
@@ -70,6 +71,11 @@ class Rat:
             self._hash = reduce(xor, map(hash, attrs))
 
         return self._hash
+
+    @property
+    def unidentified(self):
+        """ Returns if this Rat object is identified (bound to an API identity) """
+        return self.uuid is None
 
     @property
     def uuid(self):

--- a/src/packages/rescue/rat_rescue.py
+++ b/src/packages/rescue/rat_rescue.py
@@ -534,7 +534,7 @@ class Rescue:  # pylint: disable=too-many-public-methods
                     self._unidentified_rats[name.casefold()] = rat
                 else:
                     raise TypeError(f"Element '{name}' expected to be of type str"
-                                     f"str, got {type(name)}")
+                                    f"str, got {type(name)}")
         else:
             raise TypeError(f"expected type dict, got {type(value)}")
 


### PR DESCRIPTION
 - Rescue's (add/remove)_rat now simply accept a Rat object
 - no fancy cache lookups
 - removed outdated tests that verified the old behavior
 - added property to rat to tell if its an identified object

## bonus requested features
 - `Rescue.rats` is now a dictionary, `Dict[str, Rat]` by casefolded rat name.
 - `Rescue.unidentified_rats`  is now a dictionary, `Dict[str, Rat]` by casefolded rat name.

It is to my opinion the Rescue object should be naive to the source of a Rat object, only that its getting rat objects.