### PR TITLE
Infratructure/recently used rescues

### DIFF
--- a/src/packages/board/board.py
+++ b/src/packages/board/board.py
@@ -146,8 +146,8 @@ class RatBoard(abc.Mapping):
         logger.info("Rescue board online.")
         self._offline = False
         logger.info("emitting {} cached rescues to the API...", len(self._offline_rescue_storage))
-        for rescue in self._offline_rescue_storage:
-            await self._handler.update_rescue(rescue)
+        while self._offline_rescue_storage:
+            await self._handler.update_rescue(self._offline_rescue_storage.popleft())
 
     async def on_offline(self):
         logger.warning("Rescue board now offline.")

--- a/src/packages/board/board.py
+++ b/src/packages/board/board.py
@@ -137,6 +137,11 @@ class RatBoard(abc.Mapping):
 
         super(RatBoard, self).__init__()
 
+    @property
+    def recently_closed(self) -> typing.Deque[Rescue]:
+        """ Recently closed rescues """
+        return self._recently_closed
+
     async def on_online(self):
         logger.info("Rescue board online.")
         self._offline = False

--- a/src/packages/fuelrats_api/_base.py
+++ b/src/packages/fuelrats_api/_base.py
@@ -22,20 +22,41 @@ class FuelratsApiABC(abc.ABC):
 
     @abc.abstractmethod
     async def get_rescues(self) -> typing.List[Rescue]:
+        """
+        TODO: flesh this out... probably need some form of conditionals to be useful...
+
+        Returns: List of :class:`Rescue` objects
+        """
         ...
 
     @abc.abstractmethod
     async def get_rescue(self, key: UUID) -> typing.Optional[Rescue]:
+        """ Fetches a specific rescue from the API by its UUID, should it exist """
         ...
 
     @abc.abstractmethod
     async def create_rescue(self, rescue: Rescue) -> Rescue:
+        """
+        Creates a new rescue on the API based on the passed rescue
+
+        Args:
+            rescue: Rescue to create on the API
+
+        Returns:
+            :class:`Rescue` created Rescue object
+
+        Notes:
+            the returned rescue may be different than the passed, as the API fills some data in that we
+            are not responisble for (IE the api_id)
+        """
         ...
 
     @abc.abstractmethod
     async def update_rescue(self, rescue: Rescue) -> None:
+        """ Updates an existing rescue on the API against local data """
         ...
 
     @abc.abstractmethod
     async def get_rat(self, key: typing.Union[UUID, str]) -> Rat:
+        """ Fetches a :class:`Rat` from the API by its ID or nickname """
         ...


### PR DESCRIPTION
the board object now holds two additional data members:

`_recently_closed` is a deque that holds the last N resscues closed out by this board object`
 - exposed on the public interface via `recently_closed` property

`_offline_rescue_storage` is a queue that holds all rescues closed out by this board, when the board is acting in offline mode. 
This queue should empty once the board receives its on_online callback.