### PR TITLE
[feature] starter system detection

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -24,6 +24,7 @@ markers =
     galaxy: marks a test as a galaxy test
     ratsignal_parse: marks a test as a ratsignal parser test
     autocorrect: tests for the autocorrect util
+    starter_systems: tests for starter_systems util
     offline: offline-aware tests
     mechaclient: mechaclient tests
     rules: command rule tests

--- a/src/packages/utils/__init__.py
+++ b/src/packages/utils/__init__.py
@@ -10,12 +10,15 @@ See LICENSE.md
 """
 
 from .autocorrect import correct_system_name
+
+from .starter_systems import isStarterSystem
 from .ratlib import sanitize, Vector, Colors, color, bold, underline, italic, reverse, Platforms, \
     Singleton, Status, Formatting
 
 __all__ = [
-    "autocorrect",
-    "ratlib",
+    "correct_system_name",
+    "isStarterSystem",
+    "sanitize",
     "Vector",
     "Colors",
     "color",
@@ -23,8 +26,8 @@ __all__ = [
     "underline",
     "italic",
     "reverse",
-    "sanitize",
     "Platforms",
-    "Formatting",
-    "Status"
+    "Singleton",
+    "Status",
+    "Formattng"
 ]

--- a/src/packages/utils/starter_systems.py
+++ b/src/packages/utils/starter_systems.py
@@ -1,7 +1,7 @@
 """
 starter_systems.py - Verification function to attempt to detect if the reported system is permit-locked to Pilot's Federation and thus requires a starter account to assist
 
-Copyright (c) 2019 The Fuel Rat Mischief,
+Copyright (c) 2020 The Fuel Rat Mischief,
 All rights reserved.
 
 Licensed under the BSD 3-Clause License.

--- a/src/packages/utils/starter_systems.py
+++ b/src/packages/utils/starter_systems.py
@@ -1,0 +1,32 @@
+"""
+starter_systems.py - Verification function to attempt to detect if the reported system is permit-locked to Pilot's Federation and thus requires a starter account to assist
+
+Copyright (c) 2019 The Fuel Rat Mischief,
+All rights reserved.
+
+Licensed under the BSD 3-Clause License.
+
+See LICENSE.md
+
+This module is built on top of the Pydle system.
+
+"""
+
+def isStarterSystem(system: str) -> bool:
+    """
+    Take a system name and attempt to match it to a known list of permit-locked starter systems
+    Autocorrecting beyond case normalization is not attempted as all known locked starter systems are not procedurally named
+    List of permit-locked starter systems taken from https://elite-dangerous.fandom.com/wiki/Pilots%27_Federation_District and last updated 2020-01-04
+
+    Args:
+        system (str): The system name to check
+
+    Returns:
+        bool: True if the system name matches a known permit-locked starter system, False otherwise
+    """
+
+    listOfStarterSystems = ['AZOTH', 'DROMI', 'LIA FAIL', 'MATET', 'ORNA', 'OTEGINE', 'SHARUR', 'TARNKAPPE', 'TYET', 'WOLFSEGEN']
+
+    system = system.upper()
+
+    return system in listOfStarterSystems

--- a/src/packages/utils/starter_systems.py
+++ b/src/packages/utils/starter_systems.py
@@ -1,5 +1,6 @@
 """
-starter_systems.py - Verification function to attempt to detect if the reported system is permit-locked to Pilot's Federation and thus requires a starter account to assist
+starter_systems.py - Verification function to attempt to detect if the reported system is
+    permit-locked to Pilot's Federation and thus requires a starter account to assist
 
 Copyright (c) 2020 The Fuel Rat Mischief,
 All rights reserved.
@@ -12,11 +13,15 @@ This module is built on top of the Pydle system.
 
 """
 
+
 def isStarterSystem(system: str) -> bool:
     """
     Take a system name and attempt to match it to a known list of permit-locked starter systems
-    Autocorrecting beyond case normalization is not attempted as all known locked starter systems are not procedurally named
-    List of permit-locked starter systems taken from https://elite-dangerous.fandom.com/wiki/Pilots%27_Federation_District and last updated 2020-01-04
+    Autocorrecting beyond case normalization is not attempted as all known locked starter systems 
+        are not procedurally named
+    List of permit-locked starter systems taken from 
+        https://elite-dangerous.fandom.com/wiki/Pilots%27_Federation_District 
+        and last updated 2020-01-04
 
     Args:
         system (str): The system name to check
@@ -25,7 +30,8 @@ def isStarterSystem(system: str) -> bool:
         bool: True if the system name matches a known permit-locked starter system, False otherwise
     """
 
-    listOfStarterSystems = ['AZOTH', 'DROMI', 'LIA FAIL', 'MATET', 'ORNA', 'OTEGINE', 'SHARUR', 'TARNKAPPE', 'TYET', 'WOLFSEGEN']
+    listOfStarterSystems = ['AZOTH', 'DROMI', 'LIA FAIL', 'MATET', 'ORNA', 'OTEGINE', 'SHARUR', 
+        'TARNKAPPE', 'TYET', 'WOLFSEGEN']
 
     system = system.upper()
 

--- a/src/packages/utils/starter_systems.py
+++ b/src/packages/utils/starter_systems.py
@@ -17,10 +17,10 @@ This module is built on top of the Pydle system.
 def isStarterSystem(system: str) -> bool:
     """
     Take a system name and attempt to match it to a known list of permit-locked starter systems
-    Autocorrecting beyond case normalization is not attempted as all known locked starter systems 
+    Autocorrecting beyond case normalization is not attempted as all known locked starter systems
         are not procedurally named
-    List of permit-locked starter systems taken from 
-        https://elite-dangerous.fandom.com/wiki/Pilots%27_Federation_District 
+    List of permit-locked starter systems taken from
+        https://elite-dangerous.fandom.com/wiki/Pilots%27_Federation_District
         and last updated 2020-01-04
 
     Args:
@@ -30,8 +30,8 @@ def isStarterSystem(system: str) -> bool:
         bool: True if the system name matches a known permit-locked starter system, False otherwise
     """
 
-    listOfStarterSystems = ['AZOTH', 'DROMI', 'LIA FAIL', 'MATET', 'ORNA', 'OTEGINE', 'SHARUR', 
-        'TARNKAPPE', 'TYET', 'WOLFSEGEN']
+    listOfStarterSystems = ['AZOTH', 'DROMI', 'LIA FAIL', 'MATET', 'ORNA', 'OTEGINE', 'SHARUR',
+                            'TARNKAPPE', 'TYET', 'WOLFSEGEN']
 
     system = system.upper()
 

--- a/tests/unit/test_startersystems.py
+++ b/tests/unit/test_startersystems.py
@@ -1,7 +1,7 @@
 """
-test_autocorrect.py - Tests for the system auto-correction methods.
+test_startersystems.py - Tests for starter system detection function
 
-Copyright (c) 2019 The Fuel Rats Mischief,
+Copyright (c) 2020 The Fuel Rats Mischief,
 All rights reserved.
 
 Licensed under the BSD 3-Clause License.

--- a/tests/unit/test_startersystems.py
+++ b/tests/unit/test_startersystems.py
@@ -1,0 +1,29 @@
+"""
+test_autocorrect.py - Tests for the system auto-correction methods.
+
+Copyright (c) 2019 The Fuel Rats Mischief,
+All rights reserved.
+
+Licensed under the BSD 3-Clause License.
+
+See LICENSE
+"""
+
+import pytest
+
+from src.packages.utils import isStarterSystem
+
+pytestmark = [pytest.mark.unit, pytest.mark.astarter_systemsutocorrect]
+
+@pytest.mark.parametrize("system_name, expected_outcome", [
+    ("Fuelum", False),
+    ("sharur", True),
+    ("Dromi", True),
+    ("COL 285 SECTOR AB-0 85-6", False),
+    ("TarnKappe", True)
+])
+def test_startersystems(system_name, expected_outcome):
+    """
+    Test that this function correctly identifies permit-locked starter systems.
+    """
+    assert isStarterSystem(system_name) == expected_outcome


### PR DESCRIPTION
Added a function to test system name for belonging to a list of permit-locked starter systems; hopefully to be used alongside autocorrect for helpful announcement for rats about to call jumps.

Unit test supplied.

Minor fixes in utils __init__.py suggested
