### PR TITLE
Relax poetry constraint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,7 +194,7 @@ jobs:
       - run:
           name: install dependencies
           command: |
-            pip install 'poetry==1.0.0'
+            pip install 'poetry~=1.0'
             poetry add pylint-exit>=1.1.0
             poetry install --no-root
 


### PR DESCRIPTION
The poetry constraint ended up being too strict, which started causing CI build failures.

This pull request relaxes the constraint from EXACTLY `1.0.0` to any `1.0.*` release.
