### PR TITLE
Galaxy Search Update

### DIFF
--- a/src/packages/galaxy/galaxy.py
+++ b/src/packages/galaxy/galaxy.py
@@ -13,7 +13,7 @@ See LICENSE.md
 import asyncio
 import json
 import typing
-from html import escape
+from urllib.parse import urlencode
 
 import aiohttp
 
@@ -72,7 +72,7 @@ class Galaxy:
             "sort": "name",
             "limit": 1
         })
-        print(data)
+
         if 'data' in data and data['data']:
             if full_details:
                 return await self.find_system_by_id(data['data'][0]['id'])
@@ -186,8 +186,8 @@ class Galaxy:
         base_url = self.url
         param_string = ""
         if params:
-            param_string = '&'.join(
-                [f"{key}={escape(str(value))}" for key, value in params.items()]
+            param_string = urlencode(
+                [(key, value) for key, value in params.items()]
             )
         url = f"{base_url}{endpoint}?{param_string}"
         for retry in range(self.MAX_RETRIES):

--- a/src/packages/galaxy/galaxy.py
+++ b/src/packages/galaxy/galaxy.py
@@ -67,7 +67,11 @@ class Galaxy:
             A ``StarSystem`` object representing the found system, or ``None`` if none was found.
         """
 
-        data = await self._call("api/systems", {"filter[name:ilike]": name, "sort": "name", "limit": 1})
+        data = await self._call("api/systems", {
+            "filter[name:ilike]": name,
+            "sort": "name",
+            "limit": 1
+        })
         print(data)
         if 'data' in data and data['data']:
             if full_details:

--- a/src/packages/galaxy/galaxy.py
+++ b/src/packages/galaxy/galaxy.py
@@ -128,10 +128,15 @@ class Galaxy:
         Returns:
             A tuple containing the landmark StarSystem closest to the one provided, and a float
             value indicating the distance between the two.
-            May return None in the case of an API failure.
+            May return None if the provided system is not found, or
+            in the case of an API failure.
         """
 
-        data = await self._call("landmark", {"name": system.name})
+        found_system = await self.find_system_by_name(system.name)
+        if found_system is None:
+            return None
+
+        data = await self._call("landmark", {"name": found_system.name})
         if 'landmarks' in data and data['landmarks']:
             landmark = await self.find_system_by_name(data['landmarks'][0]['name'])
             return (landmark, round(data['landmarks'][0]['distance'], 2))

--- a/src/packages/galaxy/galaxy.py
+++ b/src/packages/galaxy/galaxy.py
@@ -67,12 +67,13 @@ class Galaxy:
             A ``StarSystem`` object representing the found system, or ``None`` if none was found.
         """
 
-        data = await self._call("search", {"name": name, "limit": 1})
-        if 'data' in data and data['data'] and data['data'][0]['name'].casefold() == name.casefold():
+        data = await self._call("api/systems", {"filter[name:ilike]": name, "sort": "name", "limit": 1})
+        print(data)
+        if 'data' in data and data['data']:
             if full_details:
                 return await self.find_system_by_id(data['data'][0]['id'])
             else:
-                return StarSystem(name=data['data'][0]['name'])
+                return StarSystem(name=data['data'][0]['attributes']['name'])
 
     async def find_system_by_id(self, system_id: int) -> typing.Optional[StarSystem]:
         """
@@ -107,7 +108,7 @@ class Galaxy:
             If the system given cannot be found, returns None.
         """
 
-        stars = await self._call("api/stars", {"filter[systemId:eq]": system_id})
+        stars = await self._call("api/stars", {"filter[systemId64:eq]": system_id})
         for star in stars['data']:
             if star['attributes']['isMainStar']:
                 result = star['attributes']

--- a/tests/fixtures/galaxy_fx.py
+++ b/tests/fixtures/galaxy_fx.py
@@ -25,41 +25,37 @@ def mock_system_api_server_fx():
     with HTTPServer('127.0.0.1', '4000') as httpserver:
         # System Data
         # - Fuelum
-        httpserver.expect_request("/api/systems/10283432").respond_with_data(
+        httpserver.expect_request("/api/systems/5031721931482").respond_with_data(
             """{"data": {"id": "10283432", "type": "systems", "attributes": {"id64": 5031721931482, "name": "Fuelum", "coords": {"x": 52.0, "y": -52.65625, "z": 49.8125}}, "links": {"self": "https://system.api.fuelrats.com/api/systems/10283432"}, "related": {}, "relationships": {}, "meta": {}}, "included": [], "links": {"self": "https://system.api.fuelrats.com/api/systems/10283432"}, "meta": {}}"""
         )
         # - Beagle Point
-        httpserver.expect_request("/api/systems/10369161").respond_with_data(
+        httpserver.expect_request("/api/systems/81973396946").respond_with_data(
             """{"data": {"id": "10369161", "type": "systems", "attributes": {"id64": 81973396946, "name": "Beagle Point", "coords": {"x": -1111.5625, "y": -134.21875, "z": 65269.75}}, "links": {"self": "https://system.api.fuelrats.com/api/systems/10369161"}, "related": {}, "relationships": {}, "meta": {}}, "included": [], "links": {"self": "https://system.api.fuelrats.com/api/systems/10369161"}, "meta": {}}"""
         )
         # - Eorld Pri QI-Z d1-4302
-        httpserver.expect_request("/api/systems/18082834").respond_with_data(
+        httpserver.expect_request("/api/systems/147826004709651").respond_with_data(
             """{"data": {"id": "18082834", "type": "systems", "attributes": {"id64": 147826004709651, "name": "Eorld Pri QI-Z d1-4302", "coords": {"x": -320.0, "y": -49.46875, "z": 19636.6875}}, "links": {"self": "https://system.api.fuelrats.com/api/systems/18082834"}, "related": {}, "relationships": {}, "meta": {}}, "included": [], "links": {"self": "https://system.api.fuelrats.com/api/systems/18082834"}, "meta": {}}"""
         )
         # - Prae Flyi RO-I b29-113
-        httpserver.expect_request("/api/systems/22311274").respond_with_data(
+        httpserver.expect_request("/api/systems/249152528933625").respond_with_data(
             """{"data": {"id": "22311274", "type": "systems", "attributes": {"id64": 249152528933625, "name": "Prae Flyi RO-I b29-113", "coords": {"x": -586.125, "y": -112.0625, "z": 39248.5}}, "links": {"self": "https://system.api.fuelrats.com/api/systems/22311274"}, "related": {}, "relationships": {}, "meta": {}}, "included": [], "links": {"self": "https://system.api.fuelrats.com/api/systems/22311274"}, "meta": {}}"""
         )
         # - Chua Eohn CT-F d12-2
-        httpserver.expect_request("/api/systems/19626238").respond_with_data(
+        httpserver.expect_request("/api/systems/78995497067").respond_with_data(
             """{"data": {"id": "19626238", "type": "systems", "attributes": {"id64": 78995497067, "name": "Chua Eohn CT-F d12-2", "coords": {"x": -995.5, "y": -162.59375, "z": 58857.0}}, "links": {"self": "https://system.api.fuelrats.com/api/systems/19626238"}, "related": {}, "relationships": {}, "meta": {}}, "included": [], "links": {"self": "https://system.api.fuelrats.com/api/systems/19626238"}, "meta": {}}"""
         )
         # - ANGRBONII
-        httpserver.expect_request("/api/systems/10288293").respond_with_data(
+        httpserver.expect_request("/api/systems/40557912804216").respond_with_data(
             """{"data": {"id": "10288293", "type": "systems", "attributes": {"id64": 40557912804216, "name": "Angrbonii", "coords": {"x": 61.65625, "y": -42.4375, "z": 53.59375}}, "links": {"self": "https://system.api.fuelrats.com/api/systems/10288293"}, "related": {}, "relationships": {}, "meta": {}}, "included": [], "links": {"self": "https://system.api.fuelrats.com/api/systems/10288293"}, "meta": {}}"""
-        )
-        # - Fallthrough for failed searches
-        httpserver.expect_request("/api/systems").respond_with_data(
-            """{"data":[],"included":[],"meta":{"results":{"available":0}}}"""
         )
 
         # Star Data
         # - Fuelum
-        httpserver.expect_request("/api/stars", query_string=b"filter%5BsystemId:eq%5D=1464").respond_with_data(
+        httpserver.expect_request("/api/stars", query_string=b"filter%5BsystemId64:eq%5D=5031721931482").respond_with_data(
             """{"data":[{"id":"3202571","attributes":{"id64":72062625759859420,"name":"NN 4230 B","subType":"M (Red dwarf) Star","isMainStar":false}},{"id":"3206960","attributes":{"id64":36033828740895450,"name":"Fuelum","subType":"K (Yellow-Orange) Star","isMainStar":true}}],"meta":{"results":{"available":1}}}"""
         )
         # - Angrbonii
-        httpserver.expect_request("/api/stars", query_string=b"filter%5BsystemId:eq%5D=10288293").respond_with_data(
+        httpserver.expect_request("/api/stars", query_string=b"filter%5BsystemId64:eq%5D=40557912804216").respond_with_data(
             """{"data":[{"id":"377822","attributes":{"id64":72098151950732160,"name":"Angrbonii A","subType":"L (Brown dwarf) Star","isMainStar":true}}],"meta":{"results":{"available":1}}}"""
         )
         # - Fallthrough for failed searches
@@ -69,32 +65,32 @@ def mock_system_api_server_fx():
 
         # System Searches
         # - Fuelum
-        httpserver.expect_request("/search", query_string=b"name=Fuelum&limit=1").respond_with_data(
-            """{"meta":{"name":"Fuelum","type":"Perfect match"},"data":[{"name":"Fuelum","similarity":"Perfect match","id":10283432}]}"""
+        httpserver.expect_request("/api/systems", query_string=b"filter%5Bname:ilike%5D=Fuelum&sort=name&limit=1").respond_with_data(
+            """{"data": [{"id": "5031721931482", "type": "systems", "attributes": {"name": "Fuelum", "coords": {"x": 52.0, "y": -52.65625, "z": 49.8125}}, "links": {"self": "http://sapi.fuelrats.dev/api/systems/5031721931482"}, "related": {}, "relationships": {"planets": {"data": [{"type": "bodies", "id": "684552175082246874"}, {"type": "bodies", "id": "828667363158102746"}, {"type": "bodies", "id": "504408189987427034"}, {"type": "bodies", "id": "720580972101210842"}, {"type": "bodies", "id": "540436987006391002"}, {"type": "bodies", "id": "360293001911571162"}, {"type": "bodies", "id": "468379392968463066"}, {"type": "bodies", "id": "756609769120174810"}, {"type": "bodies", "id": "576465784025354970"}, {"type": "bodies", "id": "792638566139138778"}], "links": {"self": "http://sapi.fuelrats.dev/api/systems/5031721931482/relationships/planets", "related": "http://sapi.fuelrats.dev/api/systems/5031721931482/planets"}, "meta": {"direction": "ONETOMANY", "results": {"limit": 10, "available": 10, "returned": 10}}}, "stars": {"data": [{"type": "stars", "id": "72062625759859418"}, {"type": "stars", "id": "36033828740895450"}], "links": {"self": "http://sapi.fuelrats.dev/api/systems/5031721931482/relationships/stars", "related": "http://sapi.fuelrats.dev/api/systems/5031721931482/stars"}, "meta": {"direction": "ONETOMANY", "results": {"limit": 10, "available": 2, "returned": 2}}}}, "meta": {}}], "included": [], "links": {"first": "http://sapi.fuelrats.dev/api/systems?sort=name&filter%5Bname%3Ailike%5D=fuelum&page%5Boffset%5D=0", "last": "http://sapi.fuelrats.dev/api/systems?sort=name&filter%5Bname%3Ailike%5D=fuelum&page%5Boffset%5D=0", "self": "http://sapi.fuelrats.dev/api/systems?filter[name:ilike]=fuelum&sort=name&limit=1"}, "meta": {"results": {"available": 1, "limit": 10, "offset": 0, "returned": 1}}}"""
         )
         # - Angrbonii
-        httpserver.expect_request("/search", query_string=b"name=Angrbonii&limit=1").respond_with_data(
-            """{"meta":{"name":"Angrbonii","type":"Perfect match"},"data":[{"name":"Angrbonii","similarity":"Perfect match","id":10288293}]}"""
+        httpserver.expect_request("/api/systems", query_string=b"filter%5Bname:ilike%5D=Angrbonii&sort=name&limit=1").respond_with_data(
+            """{"data": [{"id": "40557912804216", "type": "systems", "attributes": {"name": "Angrbonii", "coords": {"x": 61.65625, "y": -42.4375, "z": 53.59375}}, "links": {"self": "http://sapi.fuelrats.dev/api/systems/40557912804216"}, "related": {}, "relationships": {"planets": {"data": [{"type": "bodies", "id": "1116933265500687224"}, {"type": "bodies", "id": "720616498292083576"}, {"type": "bodies", "id": "828702889348975480"}, {"type": "bodies", "id": "792674092330011512"}, {"type": "bodies", "id": "972818077424831352"}, {"type": "bodies", "id": "936789280405867384"}, {"type": "bodies", "id": "1044875671462759288"}, {"type": "bodies", "id": "1261048453576543096"}, {"type": "bodies", "id": "1225019656557579128"}, {"type": "bodies", "id": "1297077250595507064"}], "links": {"self": "http://sapi.fuelrats.dev/api/systems/40557912804216/relationships/planets", "related": "http://sapi.fuelrats.dev/api/systems/40557912804216/planets"}, "meta": {"direction": "ONETOMANY", "results": {"limit": 10, "available": 10, "returned": 10}}}, "stars": {"data": [{"type": "stars", "id": "72098151950732152"}, {"type": "stars", "id": "144155745988660088"}, {"type": "stars", "id": "108126948969696120"}], "links": {"self": "http://sapi.fuelrats.dev/api/systems/40557912804216/relationships/stars", "related": "http://sapi.fuelrats.dev/api/systems/40557912804216/stars"}, "meta": {"direction": "ONETOMANY", "results": {"limit": 10, "available": 3, "returned": 3}}}}, "meta": {}}], "included": [], "links": {"first": "http://sapi.fuelrats.dev/api/systems?sort=name&filter%5Bname%3Ailike%5D=Angrbonii&page%5Boffset%5D=0", "last": "http://sapi.fuelrats.dev/api/systems?sort=name&filter%5Bname%3Ailike%5D=Angrbonii&page%5Boffset%5D=0", "self": "http://sapi.fuelrats.dev/api/systems?filter[name:ilike]=Angrbonii&sort=name&limit=1"}, "meta": {"results": {"available": 1, "limit": 10, "offset": 0, "returned": 1}}}"""
         )
         # - Beagle Point
-        httpserver.expect_request("/search", query_string=b"name=Beagle+Point&limit=1").respond_with_data(
-            """{"meta":{"name":"Beagle Point","type":"Perfect match"},"data":[{"name":"Beagle Point","similarity":"Perfect match","id":10369161}]}"""
+        httpserver.expect_request("/api/systems", query_string=b"filter%5Bname:ilike%5D=Beagle+Point&sort=name&limit=1").respond_with_data(
+            """{"data": [{"id": "81973396946", "type": "systems", "attributes": {"name": "Beagle Point", "coords": {"x": -1111.5625, "y": -134.21875, "z": 65269.75}}, "links": {"self": "http://sapi.fuelrats.dev/api/systems/81973396946"}, "related": {}, "relationships": {"planets": {"data": [{"type": "bodies", "id": "252201661106144722"}, {"type": "bodies", "id": "360288052163036626"}, {"type": "bodies", "id": "324259255144072658"}, {"type": "bodies", "id": "216172864087180754"}, {"type": "bodies", "id": "180144067068216786"}, {"type": "bodies", "id": "396316849182000594"}, {"type": "bodies", "id": "108086473030288850"}, {"type": "bodies", "id": "36028878992360914"}, {"type": "bodies", "id": "72057676011324882"}], "links": {"self": "http://sapi.fuelrats.dev/api/systems/81973396946/relationships/planets", "related": "http://sapi.fuelrats.dev/api/systems/81973396946/planets"}, "meta": {"direction": "ONETOMANY", "results": {"limit": 10, "available": 9, "returned": 9}}}, "stars": {"data": [{"type": "stars", "id": "81973396946"}], "links": {"self": "http://sapi.fuelrats.dev/api/systems/81973396946/relationships/stars", "related": "http://sapi.fuelrats.dev/api/systems/81973396946/stars"}, "meta": {"direction": "ONETOMANY", "results": {"limit": 10, "available": 1, "returned": 1}}}}, "meta": {}}], "included": [], "links": {"first": "http://sapi.fuelrats.dev/api/systems?sort=name&filter%5Bname%3Ailike%5D=Beagle+Point&page%5Boffset%5D=0", "last": "http://sapi.fuelrats.dev/api/systems?sort=name&filter%5Bname%3Ailike%5D=Beagle+Point&page%5Boffset%5D=0", "self": "http://sapi.fuelrats.dev/api/systems?filter[name:ilike]=Beagle+Point&sort=name&limit=1"}, "meta": {"results": {"available": 1, "limit": 10, "offset": 0, "returned": 1}}}"""
         )
         # - Eorld Pri QI-Z d1-4302
-        httpserver.expect_request("/search", query_string=b"name=Eorld+Pri+QI-Z+d1-4302&limit=1").respond_with_data(
-            """{"meta":{"name":"Eorld Pri QI-Z d1-4302","type":"Perfect match"},"data":[{"name":"Eorld Pri QI-Z d1-4302","similarity":"Perfect match","id":18082834}]}"""
+        httpserver.expect_request("/api/systems", query_string=b"filter%5Bname:ilike%5D=Eorld+Pri+QI-Z+d1-4302&sort=name&limit=1").respond_with_data(
+            """{"data": [{"id": "147826004709651", "type": "systems", "attributes": {"name": "Eorld Pri QI-Z d1-4302", "coords": {"x": -320.0, "y": -49.46875, "z": 19636.6875}}, "links": {"self": "http://sapi.fuelrats.dev/api/systems/147826004709651"}, "related": {}, "relationships": {"planets": {"data": [], "links": {"self": "http://sapi.fuelrats.dev/api/systems/147826004709651/relationships/planets", "related": "http://sapi.fuelrats.dev/api/systems/147826004709651/planets"}, "meta": {"direction": "ONETOMANY", "results": {"limit": 10, "available": 0, "returned": 0}}}, "stars": {"data": [], "links": {"self": "http://sapi.fuelrats.dev/api/systems/147826004709651/relationships/stars", "related": "http://sapi.fuelrats.dev/api/systems/147826004709651/stars"}, "meta": {"direction": "ONETOMANY", "results": {"limit": 10, "available": 0, "returned": 0}}}}, "meta": {}}], "included": [], "links": {"first": "http://sapi.fuelrats.dev/api/systems?sort=name&filter%5Bname%3Ailike%5D=Eorld+Pri+QI-Z+d1-4302&page%5Boffset%5D=0", "last": "http://sapi.fuelrats.dev/api/systems?sort=name&filter%5Bname%3Ailike%5D=Eorld+Pri+QI-Z+d1-4302&page%5Boffset%5D=0", "self": "http://sapi.fuelrats.dev/api/systems?filter[name:ilike]=Eorld+Pri+QI-Z+d1-4302&sort=name&limit=1"}, "meta": {"results": {"available": 1, "limit": 10, "offset": 0, "returned": 1}}}"""
         )
         # - Prae Flyi RO-I b29-113
-        httpserver.expect_request("/search", query_string=b"name=Prae+Flyi+RO-I+b29-113&limit=1").respond_with_data(
-            """{"meta": {"name": "Prae Flyi RO-I b29-113", "type": "Perfect match"}, "data": [{"name": "Prae Flyi RO-I b29-113", "similarity": "Perfect match","id":22311274}]}"""
+        httpserver.expect_request("/api/systems", query_string=b"filter%5Bname:ilike%5D=Prae+Flyi+RO-I+b29-113&sort=name&limit=1").respond_with_data(
+            """{"data": [{"id": "249152528933625", "type": "systems", "attributes": {"name": "Prae Flyi RO-I b29-113", "coords": {"x": -586.125, "y": -112.0625, "z": 39248.5}}, "links": {"self": "http://sapi.fuelrats.dev/api/systems/249152528933625"}, "related": {}, "relationships": {"planets": {"data": [], "links": {"self": "http://sapi.fuelrats.dev/api/systems/249152528933625/relationships/planets", "related": "http://sapi.fuelrats.dev/api/systems/249152528933625/planets"}, "meta": {"direction": "ONETOMANY", "results": {"limit": 10, "available": 0, "returned": 0}}}, "stars": {"data": [], "links": {"self": "http://sapi.fuelrats.dev/api/systems/249152528933625/relationships/stars", "related": "http://sapi.fuelrats.dev/api/systems/249152528933625/stars"}, "meta": {"direction": "ONETOMANY", "results": {"limit": 10, "available": 0, "returned": 0}}}}, "meta": {}}], "included": [], "links": {"first": "http://sapi.fuelrats.dev/api/systems?sort=name&filter%5Bname%3Ailike%5D=Prae+Flyi+RO-I+b29-113&page%5Boffset%5D=0", "last": "http://sapi.fuelrats.dev/api/systems?sort=name&filter%5Bname%3Ailike%5D=Prae+Flyi+RO-I+b29-113&page%5Boffset%5D=0", "self": "http://sapi.fuelrats.dev/api/systems?filter[name:ilike]=Prae+Flyi+RO-I+b29-113&sort=name&limit=1"}, "meta": {"results": {"available": 1, "limit": 10, "offset": 0, "returned": 1}}}"""
         )
         # - Chua Eohn CT-F d12-2
-        httpserver.expect_request("/search", query_string=b"name=Chua+Eohn+CT-F+d12-2&limit=1").respond_with_data(
-            """{"meta": {"name": "Chua Eohn CT-F d12-2", "type": "Perfect match"}, "data": [{"name": "Chua Eohn CT-F d12-2", "similarity": "Perfect match", "id": 19626238}]}"""
+        httpserver.expect_request("/api/systems", query_string=b"filter%5Bname:ilike%5D=Chua+Eohn+CT-F+d12-2&sort=name&limit=1").respond_with_data(
+            """{"data": [{"id": "78995497067", "type": "systems", "attributes": {"name": "Chua Eohn CT-F d12-2", "coords": {"x": -995.5, "y": -162.59375, "z": 58857.0}}, "links": {"self": "http://sapi.fuelrats.dev/api/systems/78995497067"}, "related": {}, "relationships": {"planets": {"data": [{"type": "bodies", "id": "288230455147208811"}, {"type": "bodies", "id": "324259252166172779"}, {"type": "bodies", "id": "360288049185136747"}, {"type": "bodies", "id": "180144064090316907"}, {"type": "bodies", "id": "252201658128244843"}], "links": {"self": "http://sapi.fuelrats.dev/api/systems/78995497067/relationships/planets", "related": "http://sapi.fuelrats.dev/api/systems/78995497067/planets"}, "meta": {"direction": "ONETOMANY", "results": {"limit": 10, "available": 5, "returned": 5}}}, "stars": {"data": [{"type": "stars", "id": "144115267071352939"}, {"type": "stars", "id": "72057673033425003"}, {"type": "stars", "id": "108086470052388971"}], "links": {"self": "http://sapi.fuelrats.dev/api/systems/78995497067/relationships/stars", "related": "http://sapi.fuelrats.dev/api/systems/78995497067/stars"}, "meta": {"direction": "ONETOMANY", "results": {"limit": 10, "available": 3, "returned": 3}}}}, "meta": {}}], "included": [], "links": {"first": "http://sapi.fuelrats.dev/api/systems?sort=name&filter%5Bname%3Ailike%5D=Chua+Eohn+CT-F+d12-2&page%5Boffset%5D=0", "last": "http://sapi.fuelrats.dev/api/systems?sort=name&filter%5Bname%3Ailike%5D=Chua+Eohn+CT-F+d12-2&page%5Boffset%5D=0", "self": "http://sapi.fuelrats.dev/api/systems?filter[name:ilike]=Chua+Eohn+CT-F+d12-2&sort=name&limit=1"}, "meta": {"results": {"available": 1, "limit": 10, "offset": 0, "returned": 1}}}"""
         )
         # - Fallthrough for failed searches
-        httpserver.expect_request("/search").respond_with_data(
-            """{"meta":{"name":"","type":"dmeta"},"data":[{"name":"h","similarity":0,"id":11633548}]}"""
+        httpserver.expect_request("/api/systems").respond_with_data(
+            """{"data":[],"included":[],"meta":{"results":{"available":0}}}"""
         )
 
         # Fuzzy Searches


### PR DESCRIPTION
This update reworks Galaxy to search for systems on the `/api/systems` endpoint using `ILIKE`, rather than the `/search` endpoint.

Additionally, as `/landmark` requires a valid system name, Galaxy will now validate systems given to `find_nearest_landmark` before attempting to search.