### PR TITLE
[SPARK-173] update docker image for new run method

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,21 +20,12 @@ WORKDIR /mechasqueak
 COPY ./poetry.lock ./
 COPY ./pyproject.toml ./
 
-# fetch git, as we will need it.
-RUN apt install git
 
 # install poetry
 RUN pip install poetry
 
-# TEMPFIX: open bug with poetry in a docker container (https://github.com/python-poetry/poetry/issues/1899)
-# The following commands work around this bug and install faster using pip
-RUN poetry config virtualenvs.create false \
-                && poetry export --without-hashes -f requirements.txt --dev \
-                |  poetry run pip install -r /dev/stdin \
-                && poetry debug
-COPY . ./
-RUN poetry install --no-interaction
 
 # Copy the current directory contents into the container at /mechasqueak
 ADD . /mechasqueak
 
+RUN pip install /mechasqueak

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,12 +20,8 @@ WORKDIR /mechasqueak
 COPY ./poetry.lock ./
 COPY ./pyproject.toml ./
 
-
-# install poetry
-RUN pip install poetry
-
-
 # Copy the current directory contents into the container at /mechasqueak
 ADD . /mechasqueak
 
+# PEP517 install
 RUN pip install /mechasqueak

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This project is under active development.  As such, features may be added or rem
 SPARK is currently **incomplete**.
 
 ## Requirements
-* Python 3.7
+* Python 3.8
 * PostgreSQL
 * Pydle >= 0.9.1
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@
 #       Mechasqueak:    docker-compose up mechasqueak
 #       Drillsqueak:    docker-compose up drillsqueak
 #       development:    docker-compose up mecha3-dev
+#       shell (for docker attach, debugging):          docker-compose up shell
 #
 #     please note that these builds require a configuration file external to git, a template
 #       configuration file is provided.
@@ -37,7 +38,27 @@ services:
 
     build: .
     image: mecha3
-    command: "pipenv run pytest"
+    command: ["python", "-m", "pytest"]
+
+  shell:
+    volumes:
+      - type: bind
+        source: ./logs
+        target: /mechasqueak/logs/
+
+      - type: bind
+        source: ./config
+        target: /mechasqueak/config/
+
+      - type: bind
+        source: ./certs
+        target: /mechasqueak/certs/
+
+    build: .
+    image: mecha3
+    command: ["/bin/bash"]
+    stdin_open: true
+    tty: true
 
   mecha3-dev:
     volumes:
@@ -54,7 +75,7 @@ services:
         target: /mechasqueak/certs/
     build: .
     image: mecha3
-    command: ["pipenv","run","python","main.py","--config", "develop.json"]
+    command: ["python","-m","src", "--config", "develop.toml"]
 
   drillsqueak:
     volumes:


### PR DESCRIPTION
This PR changes the docker configuration for the new requirements to run mecha, such as:

- Python 3.6 -> 3.8 (using python3.8 docker image)
- pipenv -> poetry

**This is not ready for merge yet, container cannot currently get configurations**. 