### PR TITLE
Spark 177 - Actually implement landmark near

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -303,7 +303,7 @@ isort = ">=4.2.5,<5"
 mccabe = ">=0.6,<0.7"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Python parsing module"
 name = "pyparsing"
 optional = false
@@ -492,7 +492,7 @@ idna = ">=2.0"
 multidict = ">=4.0"
 
 [metadata]
-content-hash = "4010c2edb8be035ddd2fa1e0a44cd82417bdd5bfd7f1ffeb9a9a4acd67fab33c"
+content-hash = "41df09921ced42c948ffbedc5deb36a288fe023fde7dc7b7f33dac3c47d25f7e"
 python-versions = ">=3.8"
 
 [metadata.files]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ toml = "*"
 loguru = "*"
 pluggy = "*"
 async_lru = "^1.0.2"
+pyparsing = "^2.4.7"
 
 [tool.poetry.dev-dependencies]
 pytest = "*"

--- a/src/commands/starsystems.py
+++ b/src/commands/starsystems.py
@@ -14,11 +14,7 @@ async def cmd_search(ctx: Context):
     return await ctx.reply(f"{results!r}")
 
 
-async def cmd_landmark_near(ctx: Context):
-    if len(ctx.words) < 2:
-        return await ctx.reply("Usage: landmark near <system>")
-
-    system_name = ctx.words_eol[1]
+async def cmd_landmark_near(ctx: Context, system_name: str):
     logger.trace("searching for system {}", system_name)
     found = await ctx.bot.galaxy.find_system_by_name(system_name)
     if not found:
@@ -26,8 +22,10 @@ async def cmd_landmark_near(ctx: Context):
             f"{system_name} was not found in The Fuel Rats System Database.")
 
     logger.debug("found system {}, acquiring nearest landmark...", found)
-    nearest_landmark = await ctx.bot.galaxy.find_nearest_landmark(found)
-    return await ctx.reply(f"{nearest_landmark}")
+    nearest_landmark, distance = await ctx.bot.galaxy.find_nearest_landmark(
+        found)
+    return await ctx.reply(
+        f"{found.name} is {distance:.2f} LY from {nearest_landmark.name}")
 
 
 @permissions.require_permission([permissions.RAT])
@@ -49,5 +47,4 @@ async def cmd_landmark(ctx: Context):
         logger.exception("failed parse", level="DEBUG")
         return await ctx.reply("Usage: `landmark near <system>")
     logger.debug("successfully parsed landmark query, result {!r}", result)
-    await ctx.reply(
-        f"OK. subcommand was {result.subcommand!r} and the system is {result.system!r}")
+    return await cmd_landmark_near(ctx, result.system)

--- a/src/commands/starsystems.py
+++ b/src/commands/starsystems.py
@@ -1,6 +1,7 @@
 from ..packages.context import Context
 from ..packages.commands import command
 from ..packages import permissions
+import pyparsing
 from loguru import logger
 
 
@@ -21,7 +22,8 @@ async def cmd_landmark_near(ctx: Context):
     logger.trace("searching for system {}", system_name)
     found = await ctx.bot.galaxy.find_system_by_name(system_name)
     if not found:
-        return await ctx.reply(f"{system_name} was not found in The Fuel Rats System Database.")
+        return await ctx.reply(
+            f"{system_name} was not found in The Fuel Rats System Database.")
 
     logger.debug("found system {}, acquiring nearest landmark...", found)
     nearest_landmark = await ctx.bot.galaxy.find_nearest_landmark(found)
@@ -31,5 +33,12 @@ async def cmd_landmark_near(ctx: Context):
 @permissions.require_permission([permissions.RAT])
 @command("landmark")
 async def cmd_landmark(ctx: Context):
+    keyword = pyparsing.oneOf("near", asKeyword=True).setResultsName(
+        "subcommand")
+    remainder = pyparsing.Word(pyparsing.alphanums + '- ').setResultsName(
+        "system")
+
+    pattern = pyparsing.Suppress(ctx.PREFIX) + pyparsing.Suppress(
+        "landmark") + keyword + remainder
     if len(ctx.words) < 2:
         return await ctx.reply("Valid subcommands: 'near'")

--- a/src/commands/starsystems.py
+++ b/src/commands/starsystems.py
@@ -32,13 +32,22 @@ async def cmd_landmark_near(ctx: Context):
 
 @permissions.require_permission([permissions.RAT])
 @command("landmark")
+@logger.catch(level="DEBUG")
 async def cmd_landmark(ctx: Context):
     keyword = pyparsing.oneOf("near", asKeyword=True).setResultsName(
         "subcommand")
     remainder = pyparsing.Word(pyparsing.alphanums + '- ').setResultsName(
         "system")
 
-    pattern = pyparsing.Suppress(ctx.PREFIX) + pyparsing.Suppress(
+    pattern = pyparsing.Suppress(
         "landmark") + keyword + remainder
-    if len(ctx.words) < 2:
-        return await ctx.reply("Valid subcommands: 'near'")
+    try:
+        logger.debug("attempting to parse landmark query {!r}",
+                     ctx.words_eol[0])
+        result = pattern.parseString(ctx.words_eol[0].casefold())
+    except pyparsing.ParseException:
+        logger.exception("failed parse", level="DEBUG")
+        return await ctx.reply("Usage: `landmark near <system>")
+    logger.debug("successfully parsed landmark query, result {!r}", result)
+    await ctx.reply(
+        f"OK. subcommand was {result.subcommand!r} and the system is {result.system!r}")


### PR DESCRIPTION
This PR resolves SPARK-177 by actually implementing `!landmark near` instead of leaving it as dead code.

While not strictly necessary, I decided to use the `pyparsing` library for this command; and intend to use it in other commands as well to simplify things. 

Originally, I used pyparsing to manage subcommands, but it appears there is exactly ONE subcommand for the `!landmark` group - `near`.
Using pyparsing ive layed the foundation if we ever want to expand this in the future.
