### PR TITLE
Preliminary Prometheus integration

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -241,6 +241,37 @@ dev = ["pre-commit", "tox"]
 
 [[package]]
 category = "main"
+description = "Async helpers for prometheus_client."
+name = "prometheus-async"
+optional = false
+python-versions = ">=2.7, !=3.0, !=3.1, !=3.2, !=3.3, !=3.4"
+version = "19.2.0"
+
+[package.dependencies]
+prometheus-client = ">=0.0.18"
+wrapt = "*"
+
+[package.extras]
+aiohttp = ["aiohttp (>=3)"]
+consul = ["aiohttp (>=3)"]
+dev = ["aiohttp (>=3)", "twisted", "aiohttp", "sphinx", "sphinxcontrib-asyncio", "coverage", "pytest (<4.1)", "pytest-twisted", "pre-commit", "pytest-asyncio"]
+docs = ["aiohttp", "sphinx", "sphinxcontrib-asyncio", "twisted"]
+tests = ["coverage", "pytest (<4.1)", "pytest-asyncio"]
+twisted = ["twisted"]
+
+[[package]]
+category = "main"
+description = "Python client for the Prometheus monitoring system."
+name = "prometheus-client"
+optional = false
+python-versions = "*"
+version = "0.7.1"
+
+[package.extras]
+twisted = ["twisted"]
+
+[[package]]
+category = "main"
 description = "psycopg2 - Python-PostgreSQL Database Adapter"
 name = "psycopg2-binary"
 optional = false
@@ -303,7 +334,7 @@ isort = ">=4.2.5,<5"
 mccabe = ">=0.6,<0.7"
 
 [[package]]
-category = "main"
+category = "dev"
 description = "Python parsing module"
 name = "pyparsing"
 optional = false
@@ -472,7 +503,7 @@ version = "1.0.1"
 dev = ["pytest (>=4.6.2)", "black (>=19.3b0)"]
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Module for decorators, wrappers and monkey patching."
 name = "wrapt"
 optional = false
@@ -492,7 +523,7 @@ idna = ">=2.0"
 multidict = ">=4.0"
 
 [metadata]
-content-hash = "41df09921ced42c948ffbedc5deb36a288fe023fde7dc7b7f33dac3c47d25f7e"
+content-hash = "30f61aa876f239e11760c18ed68075518c365a39375fe23bb42bc600b373a189"
 python-versions = ">=3.8"
 
 [metadata.files]
@@ -664,6 +695,13 @@ packaging = [
 pluggy = [
     {file = "pluggy-0.13.1-py2.py3-none-any.whl", hash = "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"},
     {file = "pluggy-0.13.1.tar.gz", hash = "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0"},
+]
+prometheus-async = [
+    {file = "prometheus_async-19.2.0-py2.py3-none-any.whl", hash = "sha256:227f516e5bf98a0dc602348381e182358f8b2ed24a8db05e8e34d9cf027bab83"},
+    {file = "prometheus_async-19.2.0.tar.gz", hash = "sha256:3cc68d1f39e9bbf16dbd0b51103d87671b3cbd1d75a72cda472cd9a35cc9d0d2"},
+]
+prometheus-client = [
+    {file = "prometheus_client-0.7.1.tar.gz", hash = "sha256:71cd24a2b3eb335cb800c7159f423df1bd4dcd5171b234be15e3f31ec9f622da"},
 ]
 psycopg2-binary = [
     {file = "psycopg2-binary-2.8.5.tar.gz", hash = "sha256:ccdc6a87f32b491129ada4b87a43b1895cf2c20fdb7f98ad979647506ffc41b6"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,8 @@ toml = "*"
 loguru = "*"
 pluggy = "*"
 async_lru = "^1.0.2"
+prometheus_client = "^0.7.1"
+prometheus_async = "^19.2.0"
 pyparsing = "^2.4.7"
 
 [tool.poetry.dev-dependencies]

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -27,6 +27,15 @@ from src.packages.commands import command
 from src.packages.context import Context
 from src.packages.permissions import require_permission, RAT
 
+import prometheus_client
+
+TIME_IN_PING = prometheus_client.Summary(
+    name="ping",
+    documentation="Time spent in the ping command",
+    namespace="command",
+    unit="seconds"
+)
+
 
 @require_permission(RAT)
 @command("ping")
@@ -35,9 +44,10 @@ async def cmd_ping(context: Context):
     Pongs a ping. lets see if the bots alive (command decorator testing)
     :param context: `Context` object for the command call.
     """
-    logger.warning(f"cmd_ping triggered on channel '{context.channel}' for user "
-                   f"'{context.user.nickname}'")
-    await context.reply(f"{context.user.nickname} pong!")
+    with TIME_IN_PING.time():
+        logger.warning(f"cmd_ping triggered on channel '{context.channel}' for user "
+                       f"'{context.user.nickname}'")
+        await context.reply(f"{context.user.nickname} pong!")
 
 
 async def start():

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -85,7 +85,7 @@ async def start():
 
 # entry point
 if __name__ == "__main__":
-    prometheus_client.start_http_server(8080, "localhost")
+    prometheus_client.start_http_server(6820, "localhost")
     LOOP = asyncio.get_event_loop()
     LOOP.run_until_complete(start())
     LOOP.run_forever()

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -85,6 +85,7 @@ async def start():
 
 # entry point
 if __name__ == "__main__":
+    prometheus_client.start_http_server(8080, "localhost")
     LOOP = asyncio.get_event_loop()
     LOOP.run_until_complete(start())
     LOOP.run_forever()

--- a/src/mechaclient.py
+++ b/src/mechaclient.py
@@ -87,6 +87,7 @@ class MechaClient(Client, MessageHistoryClient):
         self._galaxy = None
         self._start_time = datetime.now(tz=timezone.utc)
         self._on_invite = require_permission(TECHRAT)(functools.partial(self._on_invite))
+        TRACKED_MESSAGES.set_function(lambda: len(self._last_user_message))
         super().__init__(*args, **kwargs)
 
     async def on_connect(self):
@@ -276,7 +277,6 @@ class MechaClient(Client, MessageHistoryClient):
 
     @property
     def last_user_message(self) -> Dict[str, str]:
-        TRACKED_MESSAGES.set(len(self._last_user_message))
         return self._last_user_message
 
     @property

--- a/src/mechaclient.py
+++ b/src/mechaclient.py
@@ -32,7 +32,7 @@ from datetime import datetime, timezone
 import prometheus_client
 from prometheus_async.aio import time as aio_time
 
-ON_MESSAGE_TIME = prometheus_client.Summary(
+ON_MESSAGE_TIME = prometheus_client.Histogram(
     name="on_message",
     namespace="client",
     documentation="time in on_message",

--- a/src/packages/commands/rat_command.py
+++ b/src/packages/commands/rat_command.py
@@ -25,7 +25,7 @@ from pyparsing import Word, Suppress, Group, alphanums, alphas, ZeroOrMore
 import prometheus_client
 from prometheus_async.aio import time as aio_time
 
-TRIGGER_TIME = prometheus_client.Summary(
+TRIGGER_TIME = prometheus_client.Histogram(
     namespace="commands",
     name="trigger",
     unit="seconds",
@@ -36,13 +36,13 @@ TRIGGER_MISS = prometheus_client.Counter(
     name="trigger_miss",
     documentation="total times trigger couldn't handle a message"
 )
-COMMAND_TIME = prometheus_client.Summary(
+COMMAND_TIME = prometheus_client.Histogram(
     namespace="commands",
     name="in_command",
     unit="seconds",
     documentation="time spent triggering commands"
 )
-FACT_TIME = prometheus_client.Summary(
+FACT_TIME = prometheus_client.Histogram(
     namespace="commands",
     name="in_fact",
     unit="seconds",

--- a/src/packages/commands/rat_command.py
+++ b/src/packages/commands/rat_command.py
@@ -12,18 +12,21 @@ This module is built on top of the Pydle system.
 
 """
 
-from loguru import logger
-from typing import Callable, Any
+import typing
+from typing import Any, Callable, Tuple
 
+import attr
+import prometheus_client
 import psycopg2
+import pyparsing
+from loguru import logger
+from prometheus_async.aio import time as aio_time
+from pyparsing import Word, Suppress, alphanums, alphas, ZeroOrMore
 
-from src.packages.rules.rules import get_rule, clear_rules
+from src.packages.permissions import Permission
+from src.packages.rules.rules import get_rule
 from ..context import Context
 from ..ratmama.ratmama_parser import handle_ratmama_announcement
-import pyparsing
-from pyparsing import Word, Suppress, Group, alphanums, alphas, ZeroOrMore
-import prometheus_client
-from prometheus_async.aio import time as aio_time
 
 TRIGGER_TIME = prometheus_client.Histogram(
     namespace="commands",
@@ -47,6 +50,13 @@ FACT_TIME = prometheus_client.Histogram(
     name="in_fact",
     unit="seconds",
     documentation="time spent triggering facts"
+)
+TIME_IN_COMMAND = prometheus_client.Histogram(
+    namespace="commands",
+    name="time_in",
+    unit="seconds",
+    documentation="time spent triggering commands",
+    labelnames=['command']
 )
 
 
@@ -72,6 +82,34 @@ class NameCollisionException(CommandException):
 
 
 _registered_commands = {}  # pylint: disable=invalid-name
+
+
+def truthy_validator(inst, attribute, value):
+    if not value:
+        raise ValueError(value)
+
+
+@attr.dataclass
+class Command:
+    underlying: typing.Callable = attr.ib(validator=attr.validators.is_callable())
+
+    aliases: typing.Tuple[str] = attr.ib(validator=attr.validators.and_(attr.validators.deep_iterable(
+        member_validator=attr.validators.instance_of(str),
+        iterable_validator=attr.validators.instance_of(tuple)),
+        truthy_validator
+    ), )
+    require_permission: typing.Optional[Permission] = attr.ib(
+        validator=attr.validators.optional(attr.validators.instance_of(Permission)),
+        default=None
+    )
+    require_channel: bool = attr.ib(default=False, validator=attr.validators.instance_of(bool))
+    require_direct_message: bool = attr.ib(default=False, validator=attr.validators.instance_of(bool))
+    func: typing.Optional[typing.Callable] = attr.ib(default=None)
+
+    async def __call__(self, *args, **kwargs):
+        # TODO: pre-execution hooks would go here
+        with TIME_IN_COMMAND.labels(command=self.aliases[0]).time():
+            return await self.underlying(*args, **kwargs)
 
 
 @aio_time(TRIGGER_TIME)
@@ -161,7 +199,7 @@ async def handle_fact(context: Context):
         return False
 
 
-def _register(func, names: list or str) -> bool:
+def _register(func, names: typing.Union[typing.Iterable[str], str]) -> bool:
     """
     Register a new command
     :param func: function
@@ -189,7 +227,7 @@ def _register(func, names: list or str) -> bool:
     return True
 
 
-def command(*aliases):
+def command(*aliases: str, **kwargs):
     """
     Registers a command by aliases
 
@@ -209,7 +247,9 @@ def command(*aliases):
             Callable: *func*, unmodified.
         """
         logger.debug(f"Registering command aliases: {aliases}...")
-        if not _register(func, aliases):
+
+        cmd = Command(underlying=func, aliases=aliases, **kwargs)
+        if not _register(cmd, aliases):
             raise InvalidCommandException("unable to register commands.")
         logger.debug(f"Registration of {aliases} completed.")
 

--- a/src/packages/permissions/permissions.py
+++ b/src/packages/permissions/permissions.py
@@ -18,6 +18,13 @@ from typing import Any, Union, Callable, Dict, Set
 
 from src.config import CONFIG_MARKER
 from ..context import Context
+import prometheus_client
+from prometheus_async.aio import time as aio_time
+
+REQUIRE_PERMISSION_TIME = prometheus_client.Summary("permissions_require_permissions_seconds",
+                                                    "time in require_permission")
+REQUIRE_CHANNEL_TIME = prometheus_client.Summary("permissions_require_channel_seconds",
+                                                 "time in require_channel")
 
 
 @CONFIG_MARKER
@@ -289,7 +296,7 @@ def require_permission(permission: Permission,
 
             await context.reply(override_message if override_message else permission.denied_message)
 
-        return guarded
+        return aio_time(REQUIRE_PERMISSION_TIME)(guarded)
 
     return real_decorator
 


### PR DESCRIPTION
This PR implements preliminary telemetry for Mecha3,
Instrumentation of interest: 

## Histograms

 - time in `on_message`
 - time in `trigger`
 - time in `handle_fact`

## Gauges
 - size of `last_user_message`
## Counters
 - messages discarded
 - Trigger misses (triggers that end up not being anything actionable)
 - Errors (anything that invokes graceful errors via the `on_message` handler)


Demo of what these stats look like in Grafina.
![image](https://user-images.githubusercontent.com/3110986/81460038-a682e580-9157-11ea-8ccc-e74364491084.png)
Note this image is not necessarily reflective as the same size is quite small. we will need to sit a bot equipped with these features in a drill channel to get more actionable data.