### PR TITLE
Fix `inject`s parser, add platform detection support

### DIFF
--- a/src/commands/administration.py
+++ b/src/commands/administration.py
@@ -49,6 +49,6 @@ async def cmd_rehash(context: Context):
 async def cmd_version(ctx: Context):
     # FIXME pull from pyproject.toml somehow?
     try:
-        return await ctx.reply(metadata.version("pipsqueak3"))
+        return await ctx.reply(f"SPARK version {metadata.version('pipsqueak3')}")
     except metadata.PackageNotFoundError:
-        return await ctx.reply("version ?.?.? (dirty)")
+        return await ctx.reply("SPARK version ?.?.? (dirty)")

--- a/src/commands/case_management.py
+++ b/src/commands/case_management.py
@@ -105,7 +105,10 @@ INJECT_PATTERN = (
     + rescue_identifier.setResultsName("subject")
     # The following group captures in any order (&).
     + (
-        pyparsing.Optional(pyparsing.CaselessKeyword("cr")).setResultsName("code_red")
+        pyparsing.Optional(
+            pyparsing.CaselessKeyword("cr")
+            ^ pyparsing.CaselessKeyword("code red")
+        ).setResultsName("code_red")
         & pyparsing.Optional(timer("timer"))
         & pyparsing.Optional(platform).setResultsName("platform")
     )

--- a/src/commands/case_management.py
+++ b/src/commands/case_management.py
@@ -25,8 +25,14 @@ from ._list_flags import ListFlags
 from ..packages.commands import command
 from ..packages.context.context import Context
 from ..packages.epic import Epic
-from ..packages.parsing_rules import rescue_identifier, irc_name, suppress_first_word, timer, \
-    rest_of_line, platform
+from ..packages.parsing_rules import (
+    rescue_identifier,
+    irc_name,
+    suppress_first_word,
+    timer,
+    rest_of_line,
+    platform,
+)
 from ..packages.permissions.permissions import (
     require_permission,
     RAT,
@@ -57,9 +63,9 @@ CLEAR_PATTERN = (
     + pyparsing.Optional(irc_name).setResultsName("first_limpet")
 )
 CMDR_PATTERN = (
-        suppress_first_word
-        + rescue_identifier.setResultsName("subject")
-        + rest_of_line.setResultsName("new_cmdr")
+    suppress_first_word
+    + rescue_identifier.setResultsName("subject")
+    + rest_of_line.setResultsName("new_cmdr")
 )
 
 GRAB_PATTERN = suppress_first_word + rescue_identifier.setResultsName("subject")
@@ -81,9 +87,9 @@ SUB_CMD_PATTERN = (
 )
 
 SYS_PATTERN = (
-        suppress_first_word
-        + rescue_identifier.setResultsName("subject")
-        + rest_of_line.setResultsName("remainder")
+    suppress_first_word
+    + rescue_identifier.setResultsName("subject")
+    + rest_of_line.setResultsName("remainder")
 )
 
 TITLE_PATTERN = SYS_PATTERN
@@ -94,16 +100,18 @@ UNASSIGN_PATTERN = (
     + pyparsing.OneOrMore(irc_name).setResultsName("rats")
 )
 
-INJECT_PATTERN = suppress_first_word + rescue_identifier.setResultsName(
-    "subject"
-) + (pyparsing.Optional(pyparsing.CaselessKeyword("cr")).setResultsName(
-    "code_red"
-) & pyparsing.Optional(
-    timer("timer")
-) & pyparsing.Optional(platform).setResultsName(
-    "platform"
-)) + rest_of_line.setResultsName(
-    "remainder"
+INJECT_PATTERN = (
+    suppress_first_word
+    + rescue_identifier.setResultsName("subject")
+    # The following group captures in any order (&).
+    + (
+        pyparsing.Optional(pyparsing.CaselessKeyword("cr")).setResultsName("code_red")
+        & pyparsing.Optional(timer("timer"))
+        & pyparsing.Optional(platform).setResultsName("platform")
+    )
+    # This comes positionally LAST and OUTSIDE the above capture group or it
+    # catches the wrong things.
+    + rest_of_line.setResultsName("remainder")
 )
 
 CODE_RED_PATTERN = suppress_first_word + rescue_identifier.setResultsName("subject")
@@ -335,9 +343,7 @@ async def cmd_case_management_grab(ctx: Context):
 
     subject = rescue.irc_nickname.casefold() if rescue else ctx.words[1].casefold()
     logger.debug("checking for last message of irc nick {!r}...", subject)
-    last_message = ctx.bot.last_user_message.get(
-        subject
-    )
+    last_message = ctx.bot.last_user_message.get(subject)
     logger.debug("last_message = {!r}", last_message)
     if not last_message:
         return await ctx.reply(f"Cannot comply: {ctx.words[1]} has not spoken recently.")

--- a/src/commands/case_management.py
+++ b/src/commands/case_management.py
@@ -52,7 +52,7 @@ if a newly-submitted case is code red or not.
 """
 ASSIGN_PATTERN = (
     suppress_first_word
-    + (rescue_identifier).setResultsName("subject")
+    + rescue_identifier.setResultsName("subject")
     + pyparsing.OneOrMore(irc_name).setResultsName("rats")
 )
 ACTIVE_PATTERN = suppress_first_word + rescue_identifier.setResultsName("subject")
@@ -395,11 +395,11 @@ async def cmd_case_management_inject(ctx: Context):
         async with ctx.bot.board.modify_rescue(rescue) as case:
             case.add_quote(ctx.words_eol[2], ctx.user.nickname)
 
-            for keyword in ctx.words_eol[2].split():
-                if keyword.upper() in {item.value for item in Platforms}:
-                    case.platform = Platforms[keyword.upper()]
-                if tokens.code_red or tokens.timer:
-                    case.code_red = True
+            if tokens.platform:
+                case.platform = Platforms[tokens.platform[0].upper()]
+
+            if tokens.code_red or tokens.timer:
+                case.code_red = True
 
             await ctx.reply(
                 f"{case.client}'s case opened with: " f"{ctx.words_eol[2]}  (Case {case.board_index})"

--- a/src/packages/parsing_rules/__init__.py
+++ b/src/packages/parsing_rules/__init__.py
@@ -45,7 +45,7 @@ platform = (
         ^ pyparsing.CaselessLiteral("xboxone")
         ^ "pyparsing.CaselessLiteral(xbox one)"
     ).setResultsName("xbox")
-)
+) + pyparsing.WordEnd()
 """
 Matches a platform specifier
 """

--- a/src/packages/parsing_rules/__init__.py
+++ b/src/packages/parsing_rules/__init__.py
@@ -43,7 +43,7 @@ platform = (
         ^ pyparsing.CaselessLiteral("xb1")
         ^ pyparsing.CaselessLiteral("xbox")
         ^ pyparsing.CaselessLiteral("xboxone")
-        ^ "pyparsing.CaselessLiteral(xbox one)"
+        ^ pyparsing.CaselessLiteral("xbox one")
     ).setResultsName("xbox")
 ) + pyparsing.WordEnd()
 """

--- a/tests/unit/commands/test_board.py
+++ b/tests/unit/commands/test_board.py
@@ -215,7 +215,7 @@ def _test_quote_header(cr_state, message, rescue):
 @pytest.mark.parametrize("platform", (Platforms.PC, Platforms.XB, Platforms.PS))
 async def test_quote_inject_interop(bot_fx, cr_state: bool, platform: Platforms):
     inject_ctx = await Context.from_message(bot_fx, "#ratchat", "some_ov",
-                                            f"!inject subject PC sol {'cr' if cr_state else ''}")
+                                            f"!inject subject PC {'cr' if cr_state else ''} sol")
     # inject a case into existance
     await trigger(inject_ctx)
     rescue = bot_fx.board["subject"]

--- a/tests/unit/test_parsing_rules.py
+++ b/tests/unit/test_parsing_rules.py
@@ -111,10 +111,14 @@ def test_unassign_pattern(ident: IDENT_TYPE, subjects: List[str]):
 
 @given(
     ident=test_strategies.rescue_identifier(),
-    code_red=strategies.one_of(strategies.just("cr"), strategies.none()),
+    code_red=strategies.one_of(
+        strategies.none(),
+        strategies.just("cr"),
+        strategies.just("code red")
+    ),
     timer=strategies.one_of(strategies.none(), test_strategies.timer()),
     remainder=test_strategies.valid_words(),
-    platform = strategies.one_of(strategies.none(), test_strategies.platform)
+    platform=strategies.one_of(strategies.none(), test_strategies.platform)
 )
 def test_inject_pattern(
     ident: IDENT_TYPE, code_red: Optional[str], timer: Optional[str], remainder: List[str], platform: Optional[Platforms]
@@ -149,4 +153,3 @@ def test_inject_pattern(
 
         # assert equality.
         assert tokens.timer.asList() == timer_should_equal, "timer failed to parse correctly."
-

--- a/tests/unit/test_parsing_rules.py
+++ b/tests/unit/test_parsing_rules.py
@@ -134,9 +134,7 @@ def test_inject_pattern(
 
     buffer.seek(0)
     payload = buffer.read().strip()
-    import pyparsing
 
-    pyparsing.__diag__.enable_all_warnings()
     tokens = case_management.INJECT_PATTERN.parseString(payload)
     assert tokens.remainder == " ".join(remainder).strip(), "invalid remainder"
 


### PR DESCRIPTION
In review it appears that `inject` never got platform detection support.
In the process of adding this, it became evident that `inject`s pattern was incorrect.

This PR corrects that and corrects the tests that missed this regression.

Caused by #185 