### PR TITLE
[SPARK-197] use platform subtokens for !inject

### DIFF
--- a/src/commands/case_management.py
+++ b/src/commands/case_management.py
@@ -50,70 +50,69 @@ Regex matcher used to find a time within a string. Used to determine
 if a newly-submitted case is code red or not.
 """
 ASSIGN_PATTERN = (
-        suppress_first_word
-        + rescue_identifier.setResultsName("subject")
-        + pyparsing.OneOrMore(irc_name).setResultsName("rats")
+    suppress_first_word
+    + rescue_identifier.setResultsName("subject")
+    + pyparsing.OneOrMore(irc_name).setResultsName("rats")
 )
 ACTIVE_PATTERN = suppress_first_word + rescue_identifier.setResultsName("subject")
 
 CLEAR_PATTERN = (
-        suppress_first_word
-        + rescue_identifier.setResultsName("subject")
-        + pyparsing.Optional(irc_name).setResultsName("first_limpet")
+    suppress_first_word
+    + rescue_identifier.setResultsName("subject")
+    + pyparsing.Optional(irc_name).setResultsName("first_limpet")
 )
 CMDR_PATTERN = (
-        suppress_first_word
-        + rescue_identifier.setResultsName("subject")
-        + rest_of_line.setResultsName("new_cmdr")
+    suppress_first_word
+    + rescue_identifier.setResultsName("subject")
+    + rest_of_line.setResultsName("new_cmdr")
 )
 
 GRAB_PATTERN = suppress_first_word + rescue_identifier.setResultsName("subject")
 
 IRC_NICK_PATTERN = (
-        suppress_first_word
-        + rescue_identifier.setResultsName("subject")
-        + irc_name.setResultsName("new_nick")
+    suppress_first_word
+    + rescue_identifier.setResultsName("subject")
+    + irc_name.setResultsName("new_nick")
 )
 JUST_RESCUE_PATTERN = suppress_first_word + rescue_identifier.setResultsName("subject")
 
 SUB_CMD_PATTERN = (
-        suppress_first_word
-        + rescue_identifier.setResultsName("subject")
-        + (pyparsing.Word(pyparsing.nums, pyparsing.nums, min=1) + pyparsing.WordEnd())
-        .setParseAction(lambda token: int(token.quote_id[0]))
-        .setResultsName("quote_id")
-        + rest_of_line.setResultsName("remainder")
+    suppress_first_word
+    + rescue_identifier.setResultsName("subject")
+    + (pyparsing.Word(pyparsing.nums, pyparsing.nums, min=1) + pyparsing.WordEnd())
+    .setParseAction(lambda token: int(token.quote_id[0]))
+    .setResultsName("quote_id")
+    + rest_of_line.setResultsName("remainder")
 )
 
 SYS_PATTERN = (
-        suppress_first_word
-        + rescue_identifier.setResultsName("subject")
-        + rest_of_line.setResultsName("remainder")
+    suppress_first_word
+    + rescue_identifier.setResultsName("subject")
+    + rest_of_line.setResultsName("remainder")
 )
 
 TITLE_PATTERN = SYS_PATTERN
 
 UNASSIGN_PATTERN = (
-        suppress_first_word
-        + rescue_identifier.setResultsName("subject")
-        + pyparsing.OneOrMore(irc_name).setResultsName("rats")
+    suppress_first_word
+    + rescue_identifier.setResultsName("subject")
+    + pyparsing.OneOrMore(irc_name).setResultsName("rats")
 )
 
 INJECT_PATTERN = (
-        suppress_first_word
-        + rescue_identifier.setResultsName("subject")
-        # The following group captures in any order (&).
-        + (
-                pyparsing.Optional(
-                    pyparsing.CaselessKeyword("cr")
-                    ^ pyparsing.CaselessKeyword("code red")
-                ).setResultsName("code_red")
-                & pyparsing.Optional(timer("timer"))
-                & pyparsing.Optional(platform).setResultsName("platform")
-        )
-        # This comes positionally LAST and OUTSIDE the above capture group or it
-        # catches the wrong things.
-        + rest_of_line.setResultsName("remainder")
+    suppress_first_word
+    + rescue_identifier.setResultsName("subject")
+    # The following group captures in any order (&).
+    + (
+        pyparsing.Optional(
+            pyparsing.CaselessKeyword("cr") ^ pyparsing.CaselessKeyword("code red")
+        ).setResultsName("code_red")
+        & pyparsing.Optional(timer("timer"))
+        & pyparsing.Optional(platform).setResultsName("platform")
+    )
+    # This comes positionally LAST and OUTSIDE the above capture group or it
+    # catches the wrong things.
+    + rest_of_line.setResultsName("remainder")
 )
 
 CODE_RED_PATTERN = suppress_first_word + rescue_identifier.setResultsName("subject")
@@ -538,12 +537,12 @@ async def cmd_case_management_quoteid(ctx: Context):
     if rescue.quotes:
         for i, quote in enumerate(rescue.quotes):
             quote_timestamp = (
-                    humanfriendly.format_timespan(
-                        (datetime.datetime.now(tz=timezone.utc) - quote.updated_at),
-                        detailed=False,
-                        max_units=2,
-                    )
-                    + " ago"
+                humanfriendly.format_timespan(
+                    (datetime.datetime.now(tz=timezone.utc) - quote.updated_at),
+                    detailed=False,
+                    max_units=2,
+                )
+                + " ago"
             )
             await ctx.reply(f"[{i}][{quote.author} ({quote_timestamp})] {quote.message}")
 
@@ -769,7 +768,7 @@ def _list_rescue(rescue_collection, format_specifiers):
 
 
 def _rescue_filter(
-        flags: ListFlags, platform_filter: typing.Optional[Platforms], rescue: Rescue
+    flags: ListFlags, platform_filter: typing.Optional[Platforms], rescue: Rescue
 ) -> bool:
     """
     determine whether the `rescue` object is one we care about

--- a/src/commands/case_management.py
+++ b/src/commands/case_management.py
@@ -44,77 +44,76 @@ from ..packages.rat import Rat
 from ..packages.rescue import Rescue
 from ..packages.utils import Platforms, Status
 
-
 _TIME_RE = re.compile(r"(\d+)[: ](\d+)")
 """
 Regex matcher used to find a time within a string. Used to determine
 if a newly-submitted case is code red or not.
 """
 ASSIGN_PATTERN = (
-    suppress_first_word
-    + rescue_identifier.setResultsName("subject")
-    + pyparsing.OneOrMore(irc_name).setResultsName("rats")
+        suppress_first_word
+        + rescue_identifier.setResultsName("subject")
+        + pyparsing.OneOrMore(irc_name).setResultsName("rats")
 )
 ACTIVE_PATTERN = suppress_first_word + rescue_identifier.setResultsName("subject")
 
 CLEAR_PATTERN = (
-    suppress_first_word
-    + rescue_identifier.setResultsName("subject")
-    + pyparsing.Optional(irc_name).setResultsName("first_limpet")
+        suppress_first_word
+        + rescue_identifier.setResultsName("subject")
+        + pyparsing.Optional(irc_name).setResultsName("first_limpet")
 )
 CMDR_PATTERN = (
-    suppress_first_word
-    + rescue_identifier.setResultsName("subject")
-    + rest_of_line.setResultsName("new_cmdr")
+        suppress_first_word
+        + rescue_identifier.setResultsName("subject")
+        + rest_of_line.setResultsName("new_cmdr")
 )
 
 GRAB_PATTERN = suppress_first_word + rescue_identifier.setResultsName("subject")
 
 IRC_NICK_PATTERN = (
-    suppress_first_word
-    + rescue_identifier.setResultsName("subject")
-    + irc_name.setResultsName("new_nick")
+        suppress_first_word
+        + rescue_identifier.setResultsName("subject")
+        + irc_name.setResultsName("new_nick")
 )
 JUST_RESCUE_PATTERN = suppress_first_word + rescue_identifier.setResultsName("subject")
 
 SUB_CMD_PATTERN = (
-    suppress_first_word
-    + rescue_identifier.setResultsName("subject")
-    + (pyparsing.Word(pyparsing.nums, pyparsing.nums, min=1) + pyparsing.WordEnd())
-    .setParseAction(lambda token: int(token.quote_id[0]))
-    .setResultsName("quote_id")
-    + rest_of_line.setResultsName("remainder")
+        suppress_first_word
+        + rescue_identifier.setResultsName("subject")
+        + (pyparsing.Word(pyparsing.nums, pyparsing.nums, min=1) + pyparsing.WordEnd())
+        .setParseAction(lambda token: int(token.quote_id[0]))
+        .setResultsName("quote_id")
+        + rest_of_line.setResultsName("remainder")
 )
 
 SYS_PATTERN = (
-    suppress_first_word
-    + rescue_identifier.setResultsName("subject")
-    + rest_of_line.setResultsName("remainder")
+        suppress_first_word
+        + rescue_identifier.setResultsName("subject")
+        + rest_of_line.setResultsName("remainder")
 )
 
 TITLE_PATTERN = SYS_PATTERN
 
 UNASSIGN_PATTERN = (
-    suppress_first_word
-    + rescue_identifier.setResultsName("subject")
-    + pyparsing.OneOrMore(irc_name).setResultsName("rats")
+        suppress_first_word
+        + rescue_identifier.setResultsName("subject")
+        + pyparsing.OneOrMore(irc_name).setResultsName("rats")
 )
 
 INJECT_PATTERN = (
-    suppress_first_word
-    + rescue_identifier.setResultsName("subject")
-    # The following group captures in any order (&).
-    + (
-        pyparsing.Optional(
-            pyparsing.CaselessKeyword("cr")
-            ^ pyparsing.CaselessKeyword("code red")
-        ).setResultsName("code_red")
-        & pyparsing.Optional(timer("timer"))
-        & pyparsing.Optional(platform).setResultsName("platform")
-    )
-    # This comes positionally LAST and OUTSIDE the above capture group or it
-    # catches the wrong things.
-    + rest_of_line.setResultsName("remainder")
+        suppress_first_word
+        + rescue_identifier.setResultsName("subject")
+        # The following group captures in any order (&).
+        + (
+                pyparsing.Optional(
+                    pyparsing.CaselessKeyword("cr")
+                    ^ pyparsing.CaselessKeyword("code red")
+                ).setResultsName("code_red")
+                & pyparsing.Optional(timer("timer"))
+                & pyparsing.Optional(platform).setResultsName("platform")
+        )
+        # This comes positionally LAST and OUTSIDE the above capture group or it
+        # catches the wrong things.
+        + rest_of_line.setResultsName("remainder")
 )
 
 CODE_RED_PATTERN = suppress_first_word + rescue_identifier.setResultsName("subject")
@@ -395,9 +394,15 @@ async def cmd_case_management_inject(ctx: Context):
         async with ctx.bot.board.modify_rescue(rescue) as case:
             case.add_quote(ctx.words_eol[2], ctx.user.nickname)
 
-            if tokens.platform:
-                case.platform = Platforms[tokens.platform[0].upper()]
+            # check specific capture groups for existence.
+            if tokens.xbox:
+                case.platform = Platforms.XB
+            if tokens.playstation:
+                case.platform = Platforms.PS
+            if tokens.pc:
+                case.platform = Platforms.PC
 
+            # Check if either CR was explicitly stated or a timer token exists.
             if tokens.code_red or tokens.timer:
                 case.code_red = True
 
@@ -533,12 +538,12 @@ async def cmd_case_management_quoteid(ctx: Context):
     if rescue.quotes:
         for i, quote in enumerate(rescue.quotes):
             quote_timestamp = (
-                humanfriendly.format_timespan(
-                    (datetime.datetime.now(tz=timezone.utc) - quote.updated_at),
-                    detailed=False,
-                    max_units=2,
-                )
-                + " ago"
+                    humanfriendly.format_timespan(
+                        (datetime.datetime.now(tz=timezone.utc) - quote.updated_at),
+                        detailed=False,
+                        max_units=2,
+                    )
+                    + " ago"
             )
             await ctx.reply(f"[{i}][{quote.author} ({quote_timestamp})] {quote.message}")
 
@@ -764,7 +769,7 @@ def _list_rescue(rescue_collection, format_specifiers):
 
 
 def _rescue_filter(
-    flags: ListFlags, platform_filter: typing.Optional[Platforms], rescue: Rescue
+        flags: ListFlags, platform_filter: typing.Optional[Platforms], rescue: Rescue
 ) -> bool:
     """
     determine whether the `rescue` object is one we care about


### PR DESCRIPTION
In #185 I implemented the `platform` parser group to have three distinct capture groups, one per platform.
In that PR I neglected to integrate this feature into `!inject`, which causes it do do the wrong thing.

A bug exists such that if any of the detected platform derivatives other than `xb`, `ps`, `pc` were entered, inject would fail as the `platform` parser doesn't normalize the parsed tokens. It would be less effort to simply check if any of the platform subgroups are truthy than it would be to have PyParsing normalize the tokens.

closes SPARK-197