### PR TITLE
[SPARK-217|SPARK-208] Implemented Drill Mode  + config overhaul

### DIFF
--- a/src/commands/case_management.py
+++ b/src/commands/case_management.py
@@ -180,7 +180,7 @@ async def cmd_case_management_assign(ctx: Context):
             rat = Rat(name=name, uuid=None)
             await case.add_rat(rat)
 
-            if rat.name in case.unidentified_rats:
+            if rat.name in case.unidentified_rats and not ctx.DRILL_MODE:
                 await ctx.reply(f"Warning: {name!r} is NOT identified.")
 
     await ctx.reply(

--- a/src/commands/case_management.py
+++ b/src/commands/case_management.py
@@ -212,14 +212,16 @@ async def cmd_case_management_clear(ctx: Context):
         return await ctx.reply("Cannot comply: platform not set.")
     if first_limpet:
         if first_limpet in rescue.unidentified_rats:
-            return await ctx.reply(f"Cannot comply: {first_limpet!r}  is unidentified.")
-
-        if first_limpet not in rescue.rats:
+            if not ctx.DRILL_MODE:
+                return await ctx.reply(f"Cannot comply: {first_limpet!r}  is unidentified.")
+        elif first_limpet not in rescue.rats:
             return await ctx.reply(f"Cannot comply: {first_limpet!r} is not assigned to this rescue")
     async with ctx.bot.board.modify_rescue(rescue) as case:
         case.active = False
         case.status = Status.CLOSED
-        if first_limpet:
+        # If we are drill mode, just:tm: don't add the first limpet association
+        # as we probably don't have valid user data in the drill API.
+        if first_limpet and not ctx.DRILL_MODE:
             case.first_limpet = rescue.rats[first_limpet].uuid
             # TODO: Add paperwork call link here
 

--- a/src/commands/case_management.py
+++ b/src/commands/case_management.py
@@ -211,10 +211,10 @@ async def cmd_case_management_clear(ctx: Context):
     if not rescue.platform:
         return await ctx.reply("Cannot comply: platform not set.")
     if first_limpet:
-        if first_limpet in rescue.unidentified_rats:
-            if not ctx.DRILL_MODE:
-                return await ctx.reply(f"Cannot comply: {first_limpet!r}  is unidentified.")
-        elif first_limpet not in rescue.rats:
+        logger.debug("clearning rescue to FL {}", first_limpet)
+        if first_limpet in rescue.unidentified_rats and not ctx.DRILL_MODE:
+            return await ctx.reply(f"Cannot comply: {first_limpet!r}  is unidentified.")
+        if first_limpet not in rescue.rats and first_limpet not in rescue.unidentified_rats:
             return await ctx.reply(f"Cannot comply: {first_limpet!r} is not assigned to this rescue")
     async with ctx.bot.board.modify_rescue(rescue) as case:
         case.active = False

--- a/src/config/_parser.py
+++ b/src/config/_parser.py
@@ -16,25 +16,15 @@ See LICENSE
 import hashlib
 import sys
 from pathlib import Path
-from typing import Dict, Tuple, Optional, Type, Union
+from typing import Dict, Tuple, Optional
 
-import attr
 import toml
 from loguru import logger
 import graypy
 
 from src.packages.cli_manager import cli_manager
 from ._manager import PLUGIN_MANAGER
-
-
-@attr.dataclass(frozen=True)
-class GelfConfig:
-    enabled: bool = attr.ib(validator=attr.validators.instance_of(bool))
-    port: Optional[int] = attr.ib(validator=attr.validators.optional(attr.validators.instance_of(int)))
-    host: Optional[str] = attr.ib(validator=attr.validators.optional(attr.validators.instance_of(str)))
-
-    log_level: str = attr.ib(default="DEBUG", validator=attr.validators.instance_of(str))
-    send_context: bool = attr.ib(validator=attr.validators.instance_of(bool), default=False)
+from .datamodel.gelf import GelfConfig
 
 
 def setup_logging(logfile: str, gelf_configuration: Optional[GelfConfig] = None):

--- a/src/config/_parser.py
+++ b/src/config/_parser.py
@@ -134,7 +134,7 @@ def load_config(filename: str) -> Tuple[Dict, str]:
     return config_dict, checksum
 
 
-def setup(filename: str) -> Tuple[Dict, str]:
+def setup(filename: str) -> Tuple[ConfigRoot, str]:
     """
     Validates and applies the configuration from disk.
 
@@ -163,4 +163,4 @@ def setup(filename: str) -> Tuple[Dict, str]:
 
     # NOTE: these members are dynamic, and only exist at runtime. (pylint can't see them.)
     PLUGIN_MANAGER.hook.rehash_handler(data=configuration)  # pylint: disable=no-member
-    return config_dict, file_hash
+    return configuration, file_hash

--- a/src/config/_spec.py
+++ b/src/config/_spec.py
@@ -17,6 +17,7 @@ import typing
 import pluggy
 
 from ._constants import _PLUGIN_NAME
+from .datamodel import ConfigRoot
 
 VALIDATOR_SPEC = pluggy.HookspecMarker(_PLUGIN_NAME)
 REHASH_SPEC = pluggy.HookspecMarker(_PLUGIN_NAME)
@@ -39,11 +40,11 @@ def validate_config(data: typing.Dict):  # pylint: disable=unused-argument
 
 # noinspection PyUnusedLocal
 @REHASH_SPEC
-def rehash_handler(data: typing.Dict):  # pylint: disable=unused-argument
+def rehash_handler(data: ConfigRoot):  # pylint: disable=unused-argument
     """
     Apply new configuration data
 
     Args:
-        data (typing.Dict): new configuration data to apply.
+        data (ConfigRoot): new configuration data to apply.
 
     """

--- a/src/config/datamodel/__init__.py
+++ b/src/config/datamodel/__init__.py
@@ -1,3 +1,13 @@
+"""
+dataclasses for the configuration system
+
+Copyright (c) 2020 The Fuel Rat Mischief,
+All rights reserved.
+
+Licensed under the BSD 3-Clause License.
+
+See LICENSE.md
+"""
 from .root import ConfigRoot
 
 __all__ = ["ConfigRoot"]

--- a/src/config/datamodel/__init__.py
+++ b/src/config/datamodel/__init__.py
@@ -1,0 +1,3 @@
+from .root import ConfigRoot
+
+__all__ = ["ConfigRoot"]

--- a/src/config/datamodel/api.py
+++ b/src/config/datamodel/api.py
@@ -1,0 +1,22 @@
+from typing import Optional
+
+import attr
+
+
+@attr.dataclass
+class FuelratsApiConfigRoot:
+    online_mode: bool = attr.ib(validator=attr.validators.instance_of(bool), default=False)
+    uri: str = attr.ib(validator=attr.validators.instance_of(str), default="wss://localhost")
+    authorization: Optional[str] = attr.ib(
+        validator=attr.validators.optional(
+            attr.validators.instance_of(str),
+        ),
+        default=None,
+    )
+
+
+@attr.dataclass
+class StarsystemApiConfigRoot:
+    url: str = attr.ib(
+        validator=attr.validators.instance_of(str), default="https://system.api.fuelrats.com/"
+    )

--- a/src/config/datamodel/api.py
+++ b/src/config/datamodel/api.py
@@ -1,3 +1,15 @@
+"""
+External API configuration datamodel
+
+Copyright (c) 2020 The Fuel Rat Mischief,
+All rights reserved.
+
+Licensed under the BSD 3-Clause License.
+
+See LICENSE.md
+"""
+
+
 from typing import Optional
 
 import attr

--- a/src/config/datamodel/auth.py
+++ b/src/config/datamodel/auth.py
@@ -1,3 +1,14 @@
+"""
+IRC authentication configuration datamodel
+
+Copyright (c) 2020 The Fuel Rat Mischief,
+All rights reserved.
+
+Licensed under the BSD 3-Clause License.
+
+See LICENSE.md
+"""
+
 from enum import Enum
 from typing import Optional
 

--- a/src/config/datamodel/auth.py
+++ b/src/config/datamodel/auth.py
@@ -1,0 +1,33 @@
+from enum import Enum
+from typing import Optional
+
+import attr
+
+
+@attr.dataclass
+class AuthExternalConfig:
+    """ External authentication configuration """
+
+    tls_client_cert: str = attr.ib(validator=attr.validators.instance_of(str), default="./none")
+
+
+class AuthenticationMethod(Enum):
+    """ Enum of valid configuration options"""
+
+    NO_AUTH = "NO_AUTH"
+    PLAIN = "PLAIN"
+    EXTERNAL = "EXTERNAL"
+
+
+@attr.dataclass
+class AuthPlainConfig:
+    username: str = attr.ib(validator=attr.validators.instance_of(str))
+    password: str = attr.ib(validator=attr.validators.instance_of(str))
+    identity: str = attr.ib(validator=attr.validators.instance_of(str))
+
+
+@attr.dataclass
+class AuthenticationConfigRoot:
+    method: AuthenticationMethod
+    plain: Optional[AuthPlainConfig]
+    external: Optional[AuthExternalConfig]

--- a/src/config/datamodel/board.py
+++ b/src/config/datamodel/board.py
@@ -1,3 +1,15 @@
+"""
+Rescue board configuration datamodel
+
+Copyright (c) 2020 The Fuel Rat Mischief,
+All rights reserved.
+
+Licensed under the BSD 3-Clause License.
+
+See LICENSE.md
+"""
+
+
 import attr
 
 

--- a/src/config/datamodel/board.py
+++ b/src/config/datamodel/board.py
@@ -1,0 +1,6 @@
+import attr
+
+
+@attr.dataclass
+class BoardConfigRoot:
+    cycle_at: int = attr.ib(validator=attr.validators.instance_of(int))

--- a/src/config/datamodel/commands.py
+++ b/src/config/datamodel/commands.py
@@ -4,3 +4,4 @@ import attr
 @attr.dataclass
 class CommandsConfigRoot:
     prefix: str = attr.ib(validator=attr.validators.instance_of(str), default="!")
+    drill_mode: bool = attr.ib(validator=attr.validators.instance_of(bool), default=False)

--- a/src/config/datamodel/commands.py
+++ b/src/config/datamodel/commands.py
@@ -1,3 +1,15 @@
+"""
+IRC commands configuration datamodel
+
+Copyright (c) 2020 The Fuel Rat Mischief,
+All rights reserved.
+
+Licensed under the BSD 3-Clause License.
+
+See LICENSE.md
+"""
+
+
 import attr
 
 

--- a/src/config/datamodel/commands.py
+++ b/src/config/datamodel/commands.py
@@ -1,0 +1,6 @@
+import attr
+
+
+@attr.dataclass
+class CommandsConfigRoot:
+    prefix: str = attr.ib(validator=attr.validators.instance_of(str), default="!")

--- a/src/config/datamodel/database.py
+++ b/src/config/datamodel/database.py
@@ -1,0 +1,12 @@
+import attr
+
+
+@attr.dataclass
+class DatabaseConfigRoot:
+    host: str = attr.ib(validator=attr.validators.instance_of(str))
+    port: int = attr.ib(validator=attr.validators.instance_of(int))
+    dbname: str = attr.ib(validator=attr.validators.instance_of(str))
+    username: str = attr.ib(validator=attr.validators.instance_of(str))
+    password: str = attr.ib(validator=attr.validators.instance_of(str))
+    fact_table: str = attr.ib(validator=attr.validators.instance_of(str), default="fact")
+    fact_log: str = attr.ib(validator=attr.validators.instance_of(str), default="fact_log")

--- a/src/config/datamodel/database.py
+++ b/src/config/datamodel/database.py
@@ -1,3 +1,15 @@
+"""
+Database configuration datamodel
+
+Copyright (c) 2020 The Fuel Rat Mischief,
+All rights reserved.
+
+Licensed under the BSD 3-Clause License.
+
+See LICENSE.md
+"""
+
+
 import attr
 
 

--- a/src/config/datamodel/gelf.py
+++ b/src/config/datamodel/gelf.py
@@ -1,0 +1,20 @@
+from typing import Optional
+
+import attr
+
+
+@attr.dataclass(frozen=True)
+class GelfConfig:
+    enabled: bool = attr.ib(validator=attr.validators.instance_of(bool))
+    port: Optional[int] = attr.ib(validator=attr.validators.optional(attr.validators.instance_of(int)))
+    host: Optional[str] = attr.ib(validator=attr.validators.optional(attr.validators.instance_of(str)))
+
+    log_level: str = attr.ib(default="DEBUG", validator=attr.validators.instance_of(str))
+    send_context: bool = attr.ib(validator=attr.validators.instance_of(bool), default=False)
+
+
+@attr.dataclass
+class LoggingConfigRoot:
+    gelf: GelfConfig = attr.ib(validator=attr.validators.instance_of(GelfConfig))
+    base_logger: str = attr.ib(validator=attr.validators.instance_of(str))
+    log_file: str = attr.ib(validator=attr.validators.instance_of(str))

--- a/src/config/datamodel/gelf.py
+++ b/src/config/datamodel/gelf.py
@@ -1,3 +1,15 @@
+"""
+Logging configuration datamodel
+
+Copyright (c) 2020 The Fuel Rat Mischief,
+All rights reserved.
+
+Licensed under the BSD 3-Clause License.
+
+See LICENSE.md
+"""
+
+
 from typing import Optional
 
 import attr

--- a/src/config/datamodel/irc.py
+++ b/src/config/datamodel/irc.py
@@ -1,0 +1,17 @@
+import attr
+from typing import List
+
+
+@attr.dataclass
+class IRCConfigRoot:
+    nickname: str = attr.ib(validator=attr.validators.instance_of(str))
+    server: str = attr.ib(validator=attr.validators.instance_of(str))
+    port: int = attr.ib(validator=attr.validators.instance_of(int))
+    tls: bool = attr.ib(validator=attr.validators.instance_of(bool), default=False)
+    channels: List[str] = attr.ib(
+        factory=list,
+        validator=attr.validators.deep_iterable(
+            member_validator=attr.validators.instance_of(str),
+            iterable_validator=attr.validators.instance_of(list),
+        ),
+    )

--- a/src/config/datamodel/irc.py
+++ b/src/config/datamodel/irc.py
@@ -1,3 +1,15 @@
+"""
+Root IRC presence config datamodel
+
+Copyright (c) 2020 The Fuel Rat Mischief,
+All rights reserved.
+
+Licensed under the BSD 3-Clause License.
+
+See LICENSE.md
+"""
+
+
 import attr
 from typing import List
 

--- a/src/config/datamodel/permissions.py
+++ b/src/config/datamodel/permissions.py
@@ -1,0 +1,19 @@
+from typing import Set
+
+import attr
+
+
+@attr.dataclass
+class PermissionsObj:
+    vhosts: Set[str]
+    level: int
+    denied_message: str = attr.ib(default="Access Denied.")
+
+
+@attr.dataclass
+class PermissionsConfigRoot:
+    recruit: PermissionsObj
+    rat: PermissionsObj
+    overseer: PermissionsObj
+    techrat: PermissionsObj
+    administrator: PermissionsObj

--- a/src/config/datamodel/permissions.py
+++ b/src/config/datamodel/permissions.py
@@ -1,3 +1,15 @@
+"""
+IRC permissions configuration datamodel
+
+Copyright (c) 2020 The Fuel Rat Mischief,
+All rights reserved.
+
+Licensed under the BSD 3-Clause License.
+
+See LICENSE.md
+"""
+
+
 from typing import Set
 
 import attr

--- a/src/config/datamodel/ratmamma.py
+++ b/src/config/datamodel/ratmamma.py
@@ -1,0 +1,17 @@
+from typing import List
+
+import attr
+
+
+@attr.dataclass
+class RatmamaConfigRoot:
+    announcer_nics: List[str] = attr.ib(
+        validator=attr.validators.deep_iterable(
+            member_validator=attr.validators.instance_of(str),
+            iterable_validator=attr.validators.instance_of(list),
+        ),
+        default=["RatMama[Bot]"],
+    )
+    trigger_keyword: str = attr.attrib(
+        validator=attr.validators.instance_of(str), default="TESTSIGNAL"
+    )

--- a/src/config/datamodel/ratmamma.py
+++ b/src/config/datamodel/ratmamma.py
@@ -1,17 +1,24 @@
-from typing import List
+from typing import List, Set
 
 import attr
 
 
 @attr.dataclass
 class RatmamaConfigRoot:
-    announcer_nicks: List[str] = attr.ib(
+    announcer_nicks: Set[str] = attr.ib(
         validator=attr.validators.deep_iterable(
             member_validator=attr.validators.instance_of(str),
-            iterable_validator=attr.validators.instance_of(list),
+            iterable_validator=attr.validators.instance_of(set),
         ),
         default=["RatMama[Bot]"],
     )
     trigger_keyword: str = attr.attrib(
         validator=attr.validators.instance_of(str), default="TESTSIGNAL"
     )
+
+    def __attrs_post_init__(self):
+        # Casefold nicks after instantiation
+        # as its not worth adding a custom decode hook to do this in cattrs.
+        self.announcer_nicks = {nick.casefold() for nick in self.announcer_nicks}
+        # Assert we didn't somehow invalidate the dataclass.
+        attr.validate(self)

--- a/src/config/datamodel/ratmamma.py
+++ b/src/config/datamodel/ratmamma.py
@@ -5,7 +5,7 @@ import attr
 
 @attr.dataclass
 class RatmamaConfigRoot:
-    announcer_nics: List[str] = attr.ib(
+    announcer_nicks: List[str] = attr.ib(
         validator=attr.validators.deep_iterable(
             member_validator=attr.validators.instance_of(str),
             iterable_validator=attr.validators.instance_of(list),

--- a/src/config/datamodel/ratmamma.py
+++ b/src/config/datamodel/ratmamma.py
@@ -1,3 +1,15 @@
+"""
+Ratmamma parsing configuration datamodel
+
+Copyright (c) 2020 The Fuel Rat Mischief,
+All rights reserved.
+
+Licensed under the BSD 3-Clause License.
+
+See LICENSE.md
+"""
+
+
 from typing import List, Set
 
 import attr
@@ -12,9 +24,11 @@ class RatmamaConfigRoot:
         ),
         default=["RatMama[Bot]"],
     )
+    """ Messages from these users will be inspected for an client announcement. """
     trigger_keyword: str = attr.attrib(
         validator=attr.validators.instance_of(str), default="TESTSIGNAL"
     )
+    """ The word to use as a trigger for non-announced clients """
 
     def __attrs_post_init__(self):
         # Casefold nicks after instantiation

--- a/src/config/datamodel/root.py
+++ b/src/config/datamodel/root.py
@@ -1,3 +1,15 @@
+"""
+Root configuration object. Top-level configuration datamodel.
+
+Copyright (c) 2020 The Fuel Rat Mischief,
+All rights reserved.
+
+Licensed under the BSD 3-Clause License.
+
+See LICENSE.md
+"""
+
+
 from typing import List
 
 import attr

--- a/src/config/datamodel/root.py
+++ b/src/config/datamodel/root.py
@@ -1,0 +1,29 @@
+from typing import List
+
+import attr
+
+from .auth import AuthenticationConfigRoot
+from .board import BoardConfigRoot
+from .permissions import PermissionsConfigRoot
+from .irc import IRCConfigRoot
+from .gelf import LoggingConfigRoot
+from .database import DatabaseConfigRoot
+from .commands import CommandsConfigRoot
+from .api import FuelratsApiConfigRoot, StarsystemApiConfigRoot
+from .ratmamma import RatmamaConfigRoot
+
+
+@attr.dataclass
+class ConfigRoot:
+    """ Root Mechasqueak configuration object """
+
+    irc: IRCConfigRoot
+    authentication: AuthenticationConfigRoot
+    permissions: PermissionsConfigRoot
+    board: BoardConfigRoot
+    logging: LoggingConfigRoot
+    database: DatabaseConfigRoot
+    commands: CommandsConfigRoot
+    api: FuelratsApiConfigRoot
+    system_api: StarsystemApiConfigRoot
+    ratsignal_parser: RatmamaConfigRoot

--- a/src/mechaclient.py
+++ b/src/mechaclient.py
@@ -149,7 +149,13 @@ class MechaClient(Client, MessageHistoryClient):
         logger.debug(f"Sanitized {sanitized_message}, Original: {message}")
         try:
             self._last_user_message[user.casefold()] = sanitized_message  # Store sanitized message
-            ctx = await Context.from_message(self, channel=channel, sender=user, message=sanitized_message)
+            ctx = await Context.from_message(
+                self,
+                channel=channel,
+                sender=user,
+                message=sanitized_message
+            )
+
             if not ctx.words:
                 logger.trace("ignoring empty message")
                 IGNORED_MESSAGES.inc()

--- a/src/mechaclient.py
+++ b/src/mechaclient.py
@@ -147,7 +147,7 @@ class MechaClient(Client, MessageHistoryClient):
         logger.debug(f"Sanitized {sanitized_message}, Original: {message}")
         try:
             self._last_user_message[user.casefold()] = sanitized_message  # Store sanitized message
-            ctx = await Context.from_message(self, channel, user, sanitized_message)
+            ctx = await Context.from_message(self, channel=channel, sender=user, message=sanitized_message)
             if not ctx.words:
                 logger.trace("ignoring empty message")
                 IGNORED_MESSAGES.inc()

--- a/src/mechaclient.py
+++ b/src/mechaclient.py
@@ -19,9 +19,11 @@ from loguru import logger
 from uuid import uuid4
 
 from pydle import Client
+
+from .config.datamodel import ConfigRoot
 from .packages.board import RatBoard
 from .packages.commands import trigger
-from .packages.fuelrats_api.v3.interface import ApiV300WSS, ApiConfig
+from .packages.fuelrats_api.v3.interface import ApiV300WSS
 from .packages.permissions import require_permission, TECHRAT
 from .packages.context.context import Context
 from .packages.fact_manager.fact_manager import FactManager
@@ -70,7 +72,7 @@ class MechaClient(Client, MessageHistoryClient):
 
     __version__ = "3.0a"
 
-    def __init__(self, *args, mecha_config=None, **kwargs):
+    def __init__(self, *args, mecha_config: ConfigRoot, **kwargs):
         """
         Custom mechasqueak constructor
 
@@ -86,7 +88,7 @@ class MechaClient(Client, MessageHistoryClient):
         self._last_user_message: Dict[str, str] = {}  # Holds last message from user, by irc nick
         self._rat_cache = None  # TODO: replace with ratcache once it exists
         self._rat_board = None  # Instantiate Rat Board
-        self._config = mecha_config if mecha_config else {}
+        self._config = mecha_config
         self._galaxy = None
         self._start_time = datetime.now(tz=timezone.utc)
         self._on_invite = require_permission(TECHRAT)(functools.partial(self._on_invite))
@@ -100,7 +102,7 @@ class MechaClient(Client, MessageHistoryClient):
         """
         logger.debug(f"Connecting to channels...")
         # join a channel
-        for channel in self._config["irc"]["channels"]:
+        for channel in self._config.irc.channels:
             logger.debug(f"Configured channel {channel}")
             await self.join(channel)
 
@@ -135,7 +137,7 @@ class MechaClient(Client, MessageHistoryClient):
         await super().on_message(channel, user, message)
         logger.debug(f"{channel}: <{user}> {message}")
 
-        if user == self._config["irc"]["nickname"]:
+        if user == self._config.irc.nickname:
             # don't do this and the bot can get int o an infinite
             # self-stimulated positive feedback loop.
             logger.debug(f"Ignored {message} (anti-loop)")
@@ -217,7 +219,7 @@ class MechaClient(Client, MessageHistoryClient):
         API Handler property
         """
         if self._api_handler is None:
-            self._api_handler = ApiV300WSS(config=ApiConfig(**self._config['api']))
+            self._api_handler = ApiV300WSS(config=self._config.api)
             self.board.api_handler = self._api_handler
         return self._api_handler
 

--- a/src/packages/board/board.py
+++ b/src/packages/board/board.py
@@ -24,6 +24,7 @@ from src.config import CONFIG_MARKER
 from ..fuelrats_api import FuelratsApiABC, ApiException, Impersonation
 
 from ..rescue import Rescue
+from ...config.datamodel import ConfigRoot
 
 cycle_at = 15
 """
@@ -67,7 +68,7 @@ def validate_config(data: typing.Dict):  # pylint: disable=unused-argument
 
 # noinspection PyUnusedLocal
 @CONFIG_MARKER
-def rehash_handler(data: typing.Dict):  # pylint: disable=unused-argument
+def rehash_handler(data: ConfigRoot):  # pylint: disable=unused-argument
     """
     Apply new configuration data
 
@@ -76,7 +77,7 @@ def rehash_handler(data: typing.Dict):  # pylint: disable=unused-argument
 
     """
     global cycle_at
-    cycle_at = data["board"]["cycle_at"]
+    cycle_at = data.board.cycle_at
 
 
 class RatBoard(abc.Mapping):

--- a/src/packages/context/context.py
+++ b/src/packages/context/context.py
@@ -47,6 +47,7 @@ def rehash_handler(data: ConfigRoot):
         data(typing.Dict): configuration object
     """
     Context.PREFIX = data.commands.prefix
+    Context.DRILL_MODE = data.commands.drill_mode
     logger.debug(f"in rehash handler, using new prefix {Context.PREFIX}")
 
 
@@ -73,6 +74,7 @@ class Context:
     )
     prefixed: bool = attr.ib(validator=attr.validators.instance_of(bool), default=False)
     PREFIX: ClassVar[str] = "<!!NOTSET!!>"
+    DRILL_MODE: ClassVar[bool] = False
 
     @property
     def channel(self) -> typing.Optional[str]:

--- a/src/packages/context/context.py
+++ b/src/packages/context/context.py
@@ -20,6 +20,7 @@ from loguru import logger
 
 from src.config import CONFIG_MARKER
 from ..user import User
+from ...config.datamodel import ConfigRoot
 
 if typing.TYPE_CHECKING:
     from src.mechaclient import MechaClient
@@ -38,14 +39,14 @@ def validate_config(data: typing.Dict):
 
 
 @CONFIG_MARKER
-def rehash_handler(data: typing.Dict):
+def rehash_handler(data: ConfigRoot):
     """
     Apply context-related configuration values from event
 
     Args:
         data(typing.Dict): configuration object
     """
-    Context.PREFIX = data["commands"]["prefix"]
+    Context.PREFIX = data.commands.prefix
     logger.debug(f"in rehash handler, using new prefix {Context.PREFIX}")
 
 

--- a/src/packages/database/database_manager.py
+++ b/src/packages/database/database_manager.py
@@ -13,6 +13,7 @@ from loguru import logger
 from psycopg2 import sql, pool
 
 from src.config import CONFIG_MARKER
+from src.config.datamodel import ConfigRoot
 
 
 class DatabaseManager:
@@ -55,7 +56,7 @@ class DatabaseManager:
 
     @classmethod
     @CONFIG_MARKER
-    def rehash_handler(cls, data: typing.Dict):
+    def rehash_handler(cls, data: ConfigRoot):
         """
         Apply new configuration data
 
@@ -109,20 +110,20 @@ class DatabaseManager:
 
             # Utilize function arguments if they are provided,
             # otherwise retrieve from config file and use those values.
-            self._dbhost = dbhost if dbhost is not None else self._config["database"].get("host")
+            self._dbhost = dbhost if dbhost is not None else self._config.database.host
             assert self._dbhost
 
-            self._dbport = dbport if dbhost is not None else self._config["database"].get("port")
+            self._dbport = dbport if dbhost is not None else self._config.database.port
             assert self._dbport
 
-            self._dbname = dbname if dbname is not None else self._config["database"].get("dbname")
+            self._dbname = dbname if dbname is not None else self._config.database.dbname
             assert self._dbname
 
-            self._dbuser = dbuser if dbuser is not None else self._config["database"].get("username")
+            self._dbuser = dbuser if dbuser is not None else self._config.database.username
             assert self._dbuser
 
             self._dbpass = (
-                dbpassword if dbpassword is not None else self._config["database"].get("password")
+                dbpassword if dbpassword is not None else self._config.database.password
             )
             assert self._dbpass
 

--- a/src/packages/fact_manager/fact_manager.py
+++ b/src/packages/fact_manager/fact_manager.py
@@ -19,6 +19,7 @@ from loguru import logger
 from .fact import Fact
 from ..database import DatabaseManager
 from src.config import CONFIG_MARKER
+from ...config.datamodel import ConfigRoot
 
 
 class FactManager(DatabaseManager):
@@ -37,7 +38,7 @@ class FactManager(DatabaseManager):
 
     @classmethod
     @CONFIG_MARKER
-    def rehash_handler(cls, data: typing.Dict):
+    def rehash_handler(cls, data: ConfigRoot):
         """
         Apply new configuration data
 
@@ -50,8 +51,8 @@ class FactManager(DatabaseManager):
     def __init__(self, fact_table=None, fact_log=None):
 
         # Pull table names from config file
-        self._fact_table = fact_table if fact_table else self._config['database']['fact_table']
-        self._fact_log = fact_log if fact_log else self._config['database']['fact_log']
+        self._fact_table = fact_table if fact_table else self._config.database.fact_table
+        self._fact_log = fact_log if fact_log else self._config.database.fact_log
 
         # Validate passed or configured table names
         if not isinstance(self._fact_table, str):

--- a/src/packages/fuelrats_api/_base.py
+++ b/src/packages/fuelrats_api/_base.py
@@ -7,6 +7,8 @@ from uuid import UUID
 
 import attr
 
+from ...config.datamodel.api import FuelratsApiConfigRoot
+
 if typing.TYPE_CHECKING:
     from ..rat.rat import Rat
     from ..rescue import Rescue
@@ -15,20 +17,13 @@ Impersonation = typing.TypeVar("Impersonation", str, UUID)
 """ Type for an ID of the user Mecha is performing an API action on the behalf of """
 
 
-@attr.dataclass
-class ApiConfig:
-    online_mode: bool = attr.ib(validator=attr.validators.instance_of(bool))
-    uri: str = attr.ib(validator=attr.validators.instance_of(str))
-    authorization: Optional[str] = attr.ib(
-        validator=attr.validators.optional(attr.validators.instance_of(str))
-    )
 
 
 @attr.dataclass(eq=False)
 class FuelratsApiABC(abc.ABC):
     rat_converter: ApiConverter[Rat]
     rescue_converter: ApiConverter[Rescue]
-    config: ApiConfig
+    config: FuelratsApiConfigRoot
     __slots__ = ["rat_converter", "rescue_converter", "config"]
 
     @abc.abstractmethod

--- a/src/packages/fuelrats_api/_base.py
+++ b/src/packages/fuelrats_api/_base.py
@@ -17,8 +17,6 @@ Impersonation = typing.TypeVar("Impersonation", str, UUID)
 """ Type for an ID of the user Mecha is performing an API action on the behalf of """
 
 
-
-
 @attr.dataclass(eq=False)
 class FuelratsApiABC(abc.ABC):
     rat_converter: ApiConverter[Rat]

--- a/src/packages/galaxy/galaxy.py
+++ b/src/packages/galaxy/galaxy.py
@@ -22,6 +22,7 @@ from loguru import logger
 from src.config import CONFIG_MARKER
 from .star_system import StarSystem
 from ..utils import Vector
+from ...config.datamodel import ConfigRoot
 
 
 class Galaxy:
@@ -32,7 +33,7 @@ class Galaxy:
 
     @classmethod
     @CONFIG_MARKER
-    def rehash_handler(cls, data: typing.Dict):
+    def rehash_handler(cls, data: ConfigRoot):
         """
         Apply new configuration data
 
@@ -51,7 +52,7 @@ class Galaxy:
     "A ClientTimeout object representing the total time an HTTP request can take before failing."
 
     def __init__(self, url: str = None):
-        self.url = url or self._config['system_api']['url']
+        self.url = url or self._config.system_api.url
 
     @alru_cache()
     async def find_system_by_name(self,

--- a/src/packages/permissions/permissions.py
+++ b/src/packages/permissions/permissions.py
@@ -11,7 +11,7 @@ See LICENSE.md
 This module is built on top of the Pydle system.
 
 """
-
+import cattr
 from loguru import logger
 from functools import wraps
 from typing import Any, Union, Callable, Dict, Set
@@ -20,6 +20,8 @@ from src.config import CONFIG_MARKER
 from ..context import Context
 import prometheus_client
 from prometheus_async.aio import time as aio_time
+
+from ...config.datamodel import ConfigRoot
 
 REQUIRE_PERMISSION_TIME = prometheus_client.Summary("permissions_require_permissions_seconds",
                                                     "time in require_permission")
@@ -63,7 +65,7 @@ def validate_config(data: Dict):
 
 
 @CONFIG_MARKER
-def rehash_handler(data: Dict):
+def rehash_handler(data: ConfigRoot):
     """
     Apply new configuration data
 
@@ -72,11 +74,11 @@ def rehash_handler(data: Dict):
 
     """
     logger.debug("applying new permissions scheme...")
-    RECRUIT.update(data['permissions']['recruit'])
-    RAT.update(data['permissions']['rat'])
-    OVERSEER.update(data['permissions']['overseer'])
-    TECHRAT.update(data['permissions']['techrat'])
-    ADMIN.update(data['permissions']['administrator'])
+    RECRUIT.update(cattr.unstructure(data.permissions.recruit))
+    RAT.update(cattr.unstructure(data.permissions.rat))
+    OVERSEER.update(cattr.unstructure(data.permissions.overseer))
+    TECHRAT.update(cattr.unstructure(data.permissions.techrat))
+    ADMIN.update(cattr.unstructure(data.permissions.administrator))
 
 
 class Permission:

--- a/src/packages/ratmama/ratmama_parser.py
+++ b/src/packages/ratmama/ratmama_parser.py
@@ -45,6 +45,7 @@ def rehash_handler(data: ConfigRoot):
     global _config
     _config = data.ratsignal_parser
 
+
 RATMAMA_REGEX = re.compile(
     r"""(?x)
     # The above makes whitespace and comments in the pattern ignored.

--- a/src/packages/ratmama/ratmama_parser.py
+++ b/src/packages/ratmama/ratmama_parser.py
@@ -26,27 +26,15 @@ from ..utils import Platforms, color, Colors, bold
 
 import attr
 
-
-@attr.dataclass
-class RatmamaConfig:
-    announcer_nicks: List[str] = attr.ib(
-        validator=attr.validators.deep_iterable(
-            attr.validators.instance_of(str), attr.validators.instance_of(list)
-        )
-    )
-    """ nicknames that may announce cases """
-    trigger_keyword: str = attr.ib(validator=attr.validators.instance_of(str))
-    """trigger keyword """
-
-    config_blob: Dict = attr.ib(validator=attr.validators.instance_of(dict))
-    """ overall configuration blob """
+from ...config.datamodel import ConfigRoot
+from ...config.datamodel.ratmamma import RatmamaConfigRoot
 
 
-_config: RatmamaConfig
+_config: RatmamaConfigRoot
 
 
 @CONFIG_MARKER
-def rehash_handler(data: Dict):
+def rehash_handler(data: ConfigRoot):
     """
     Apply new configuration data
 
@@ -55,14 +43,7 @@ def rehash_handler(data: Dict):
 
     """
     global _config
-    _config = RatmamaConfig(config_blob=data, **data["ratsignal_parser"])
-
-
-@CONFIG_MARKER
-def validate_config(data: Dict):
-    # the dataclass does its own validation
-    RatmamaConfig(config_blob=data, **data["ratsignal_parser"])
-
+    _config = data.ratsignal_parser
 
 RATMAMA_REGEX = re.compile(
     r"""(?x)

--- a/src/packages/ratmama/ratmama_parser.py
+++ b/src/packages/ratmama/ratmama_parser.py
@@ -103,8 +103,9 @@ async def handle_ratmama_announcement(ctx: Context) -> None:
 
     """
 
-    if ctx.user.nickname.casefold() not in (nick.casefold() for nick in _config.announcer_nicks):
-        return
+    # If the user isn't one that is allowed to trigger this code,
+    if ctx.user.nickname.casefold() not in _config.announcer_nicks:
+        return  # then SKIP!
 
     message: str = ctx.words_eol[0]
     result = re.fullmatch(RATMAMA_REGEX, message)
@@ -186,6 +187,10 @@ async def handle_ratmama_announcement(ctx: Context) -> None:
         platform=platform,
     )
     platform_signal = f"({rescue.platform.value.upper()}_SIGNAL)" if rescue.platform else ""
+
+    # [SPARK-217]: Don't emit  Platform signals in drill mode.
+    if ctx.DRILL_MODE:
+        platform_signal = ""
 
     distance_str = "not found in the galaxy DB"
     try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,7 @@ import pytest
 
 # from psycopg2.pool import SimpleConnectionPool
 from src.config import CONFIG_MARKER, PLUGIN_MANAGER, setup_logging, setup
-from src.config._parser import GelfConfig
+from src.config.datamodel.gelf import GelfConfig
 from src.packages import cli_manager
 from src.packages.cache.rat_cache import RatCache
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,12 +23,13 @@ import pytest
 
 # from psycopg2.pool import SimpleConnectionPool
 from src.config import CONFIG_MARKER, PLUGIN_MANAGER, setup_logging, setup
+from src.config.datamodel import ConfigRoot
+from src.config.datamodel.api import FuelratsApiConfigRoot
 from src.config.datamodel.gelf import GelfConfig
 from src.packages import cli_manager
 from src.packages.cache.rat_cache import RatCache
 
 # Set argv to keep cli arguments meant for pytest from polluting our things
-from src.packages.fuelrats_api._base import ApiConfig
 from src.packages.fuelrats_api.v3.interface import ApiV300WSS
 from tests.fixtures.mock_websocket import FakeConnection, Expectation
 
@@ -348,11 +349,11 @@ class ConfigReceiver:
     """
     Namespace plugin for hooking into config events
     """
-    data: Dict = {}
+    data: ConfigRoot
 
     @classmethod
     @CONFIG_MARKER
-    def rehash_handler(cls, data: Dict):
+    def rehash_handler(cls, data: ConfigRoot):
         cls.data = data
 
 
@@ -372,7 +373,7 @@ def global_init_fx() -> None:
 
 
 @pytest.fixture(scope="session")
-def configuration_fx() -> Dict:
+def configuration_fx() -> ConfigRoot:
     """
     provides the session configuration dictionary, as loaded at test session start.
     """
@@ -402,7 +403,7 @@ def api_wss_connection_fx() -> FakeConnection:
 
 @pytest.fixture
 def api_wss_fx(api_wss_connection_fx) -> ApiV300WSS:
-    interface = ApiV300WSS(connection=api_wss_connection_fx, config=ApiConfig(
+    interface = ApiV300WSS(connection=api_wss_connection_fx, config=FuelratsApiConfigRoot(
         online_mode=False, uri="localhost", authorization=None
     ))
     interface.connected_event.set()

--- a/tests/fixtures/mock_websocket.py
+++ b/tests/fixtures/mock_websocket.py
@@ -2,7 +2,6 @@ from typing import List, Optional
 
 import pytest
 
-from src.packages.fuelrats_api._base import ApiConfig
 from src.packages.fuelrats_api.v3.interface import ApiV300WSS, Connection
 import attr
 import asyncio

--- a/tests/unit/test_database_manager.py
+++ b/tests/unit/test_database_manager.py
@@ -132,6 +132,6 @@ async def test_db_query_direct(test_dbm_fx):
          'username': 'root',
          'password': 'mecha'}
 ))
-def test_validate_config_invalid(configuration_fx, data, test_dbm_fx):
+def test_validate_config_invalid(data, test_dbm_fx):
     with pytest.raises(ValueError):
         test_dbm_fx.validate_config(data={'database': data})

--- a/tests/unit/test_mechaclient.py
+++ b/tests/unit/test_mechaclient.py
@@ -182,7 +182,7 @@ async def test_mechaclient_on_message_anti_loop(bot_fx):
                                                      "lul, 0mg haxor",
                                                      "wr+ #3",
                                                      "925300 minutes"])
-@pytest.mark.parametrize("mechaclient_irc_names", ["rat_2412", "Shaott", "xXxN00BR4TxXx"])
+@pytest.mark.parametrize("mechaclient_irc_names", ["some_recruit", "some_ov", "some_service"])
 @pytest.mark.asyncio
 async def test_mechaclient_on_message_handling(bot_fx, mechaclient_irc_chatter,
                                                mechaclient_irc_names):

--- a/tests/unit/test_rat_command.py
+++ b/tests/unit/test_rat_command.py
@@ -65,7 +65,7 @@ class TestRatCommand(object):
         Verifiy that found commands can be invoked via Commands.Trigger()
         """
 
-        trigger_alias = f"{configuration_fx['commands']['prefix']}{alias}"
+        trigger_alias = f"{configuration_fx.commands.prefix}{alias}"
 
         @Commands.command(alias)
         async def potato(context: Context):

--- a/tests/unit/test_rat_command.py
+++ b/tests/unit/test_rat_command.py
@@ -27,12 +27,14 @@ from src.packages.context.context import Context
 @pytest.mark.commands
 class TestRatCommand(object):
     @pytest.mark.asyncio
-    async def test_invalid_command(self):
+    async def test_invalid_command(self, bot_fx):
         """
         Ensures that nothing happens and `trigger` exits quietly when no command can be found.
         """
-        await Commands.trigger(Context(None, None, "#unit_test", ['!unknowncommandsad hi!'],
-                                       ['!unknowncommandsad hi!', "hi!"]))
+        ctx = await Context.from_message(
+            bot_fx, "#unittest", "some_recruit", "!unknowncommandsad hi!"
+        )
+        await Commands.trigger(ctx)
 
     @pytest.mark.parametrize("alias", ['potato', 'cannon', 'Fodder', 'fireball'])
     def test_double_command_registration(self, alias):


### PR DESCRIPTION
This PR does two things.

# Configuration overhaul
With `cattrs` proving effective in handling nested dictionaries and complex data types, we can replace the nested dict structure that is our current configuration handling with attrs dataclasses instead!

The benefits of this are two fold:
the fields of the configuration can be known statically, and can be tab completed. This leads to cleaner syntax.
The configuration becomes a distinct type instead of a nested dictionary, and has supports for many more primitive types such as Sets and Enums. 

If we add defaults for everything, we could even generate a template configuration file at runtime!

# SPARK-217: Drill mode
This PR adds an additional configuration setting under `commands.drill_mode:bool`, which is the configuration toggle for SPARK-217's drill mode. When True, SPARK-217's features will be enabled. This is achieved by forwarding this configuration into `Context` by the means of a classvar on that class. Commands can simply check `Context.DRILL_MODE:bool` and modify their behavior to match. Reference modifications have been made to !inject and !clear to make use of this new feature and implement the requirements of SPARK-217


# SPARK-208: Hardcoded drill signals instead of emitting platform-specific signals in drill mode
This PR expands upon SPARK-217 by implementing the related SPARK-208 feature. Mecha will now NOT emit platform signals in drill mode.