### PR TITLE
[SPARK-235] Make telemetry configurable

### DIFF
--- a/src/__main__.py
+++ b/src/__main__.py
@@ -85,11 +85,16 @@ async def start():
                          )
 
     logger.info("Connected to IRC.")
+    if config.telemetry.enabled:
+        logger.info("spawning telemetry client...")
+        prometheus_client.start_http_server(
+            config.telemetry.bind_port,
+            f"{config.telemetry.bind_host}"
+        )
 
 
 # entry point
 if __name__ == "__main__":
-    prometheus_client.start_http_server(6820, "localhost")
     LOOP = asyncio.get_event_loop()
     LOOP.run_until_complete(start())
     LOOP.run_forever()

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -86,7 +86,7 @@ async def start():
 
     logger.info("Connected to IRC.")
     if config.telemetry.enabled:
-        logger.info("spawning telemetry client...")
+        logger.info("spawning telemetry client w config {}", config.telemetry)
         prometheus_client.start_http_server(
             config.telemetry.bind_port,
             f"{config.telemetry.bind_host}"

--- a/src/config/datamodel/__init__.py
+++ b/src/config/datamodel/__init__.py
@@ -8,6 +8,22 @@ Licensed under the BSD 3-Clause License.
 
 See LICENSE.md
 """
+from ipaddress import ip_address, IPv4Address, IPv6Address
+
+from .prometheus import IPAddress
 from .root import ConfigRoot
+import cattr
 
 __all__ = ["ConfigRoot"]
+
+
+def structure_ip_address(raw: str, *args) -> IPAddress:
+    return ip_address(raw)
+
+
+cattr.register_structure_hook(IPAddress, structure_ip_address)
+cattr.register_structure_hook(IPv4Address, structure_ip_address)
+cattr.register_structure_hook(IPv6Address, structure_ip_address)
+
+cattr.register_unstructure_hook(IPv6Address, lambda data: f"{data}")
+cattr.register_unstructure_hook(IPv4Address, lambda data: f"{data}")

--- a/src/config/datamodel/prometheus.py
+++ b/src/config/datamodel/prometheus.py
@@ -1,0 +1,16 @@
+from ipaddress import IPv4Address, IPv6Address, ip_address
+from typing import Union
+
+import attr
+
+IPAddress = Union[IPv6Address, IPv4Address]
+
+
+@attr.define
+class TelemetryConfigRoot:
+    bind_host: IPAddress = attr.ib(
+        validator=attr.validators.instance_of((IPv4Address, IPv6Address)),
+        default=ip_address("172.0.0.1"),
+    )
+    bind_port: int = attr.ib(validator=attr.validators.instance_of(int), default=6820)
+    enabled: bool = attr.ib(validator=attr.validators.instance_of(bool), default=False)

--- a/src/config/datamodel/prometheus.py
+++ b/src/config/datamodel/prometheus.py
@@ -10,7 +10,7 @@ IPAddress = Union[IPv6Address, IPv4Address]
 class TelemetryConfigRoot:
     bind_host: IPAddress = attr.ib(
         validator=attr.validators.instance_of((IPv4Address, IPv6Address)),
-        default=ip_address("172.0.0.1"),
+        default=ip_address("127.0.0.1"),
     )
     bind_port: int = attr.ib(validator=attr.validators.instance_of(int), default=6820)
     enabled: bool = attr.ib(validator=attr.validators.instance_of(bool), default=False)

--- a/src/config/datamodel/root.py
+++ b/src/config/datamodel/root.py
@@ -9,7 +9,6 @@ Licensed under the BSD 3-Clause License.
 See LICENSE.md
 """
 
-
 from typing import List
 
 import attr
@@ -23,6 +22,7 @@ from .database import DatabaseConfigRoot
 from .commands import CommandsConfigRoot
 from .api import FuelratsApiConfigRoot, StarsystemApiConfigRoot
 from .ratmamma import RatmamaConfigRoot
+from .prometheus import TelemetryConfigRoot
 
 
 @attr.dataclass
@@ -39,3 +39,4 @@ class ConfigRoot:
     api: FuelratsApiConfigRoot
     system_api: StarsystemApiConfigRoot
     ratsignal_parser: RatmamaConfigRoot
+    telemetry: TelemetryConfigRoot = attr.ib(factory=TelemetryConfigRoot)


### PR DESCRIPTION
This PR makes the prometheus telemetry server configurable, specifically the bind host and port.
This PR adds sensible (read: disable telemetry) defaults, such that no changes to existing configuration files is required.
By default, telemetry will be disabled unless explicitly re-enabled in configuration files under the new `[telemetry]` key.
