### PR TITLE
[SPARK-154] Fix inconsistent commands implementation

### DIFF
--- a/src/__main__.py
+++ b/src/__main__.py
@@ -38,8 +38,7 @@ TIME_IN_PING = prometheus_client.Summary(
 )
 
 
-@require_permission(RAT)
-@command("ping")
+@command("ping", require_permission=RAT)
 async def cmd_ping(context: Context):
     """
     Pongs a ping. lets see if the bots alive (command decorator testing)

--- a/src/commands/administration.py
+++ b/src/commands/administration.py
@@ -11,21 +11,24 @@ Licensed under the BSD 3-Clause License.
 See LICENSE.md
 """
 
+from importlib import metadata
+
+from loguru import logger
+
 from ..config import setup
 from ..packages.cli_manager import cli_manager
 from ..packages.commands import command
 from ..packages.context import Context
-from ..packages.permissions import require_channel, require_permission, TECHRAT
-from loguru import logger
-from importlib import metadata
-import src
-from importlib import resources
-import toml
+from ..packages.permissions import TECHRAT, RECRUIT
 
 
-@command("rehash")
-@require_channel(message="please do this where everyone can see 😒")
-@require_permission(TECHRAT, override_message="no.")
+@command(
+    "rehash",
+    require_channel=True,
+    override_channel_message="please do this where everyone can see 😒",
+    require_permission=TECHRAT,
+    require_permission_message="no.",
+)
 async def cmd_rehash(context: Context):
     """ rehash the hash browns. (reloads config file)"""
     logger.warning(f"config rehashing invoked by user {context.user.nickname}")
@@ -45,9 +48,8 @@ async def cmd_rehash(context: Context):
         await context.reply(f"rehashing completed successfully. ({resulting_hash[:8]}) ")
 
 
-@command("version")
+@command("version", require_permission=RECRUIT)
 async def cmd_version(ctx: Context):
-    # FIXME pull from pyproject.toml somehow?
     try:
         return await ctx.reply(f"SPARK version {metadata.version('pipsqueak3')}")
     except metadata.PackageNotFoundError:

--- a/src/commands/api_utilities.py
+++ b/src/commands/api_utilities.py
@@ -18,8 +18,7 @@ from ..packages.parsing_rules import (
 RATID_PATTERN = suppress_first_word + irc_name.setResultsName("subject")
 
 
-@require_permission(RAT)
-@command("ratid")
+@command("ratid", require_permission=RAT)
 async def cmd_ratid(context: Context):
     if not RATID_PATTERN.matches(context.words_eol[0]):
         return await context.reply("Usage: !ratid <irc_nickname>")

--- a/src/commands/case_management.py
+++ b/src/commands/case_management.py
@@ -15,6 +15,7 @@ import itertools
 import re
 import typing
 import uuid
+import warnings
 from datetime import timezone
 
 import humanfriendly
@@ -121,9 +122,7 @@ CODE_RED_PATTERN = suppress_first_word + rescue_identifier.setResultsName("subje
 REOPEN_PATTERN = suppress_first_word + api_id.setResultsName("subject")
 
 
-@require_channel
-@require_permission(RAT)
-@command("active", "activate", "inactive", "deactivate")
+@command("active", "activate", "inactive", "deactivate", require_permission=RAT, require_channel=True)
 async def cmd_case_management_active(ctx: Context):
     """
     Toggles the indicated case as active or inactive.  Requires an OPEN case.
@@ -152,9 +151,7 @@ async def cmd_case_management_active(ctx: Context):
         await ctx.reply(f'{case.client}\'s case is now {"Active" if case.active else "Inactive"}.')
 
 
-@require_channel
-@require_permission(RAT)
-@command("assign", "add", "go")
+@command("assign", "add", "go", require_channel=True, require_permission=RAT)
 async def cmd_case_management_assign(ctx: Context):
     if not ASSIGN_PATTERN.matches(ctx.words_eol[0]):
         await ctx.reply("Usage: !assign <Client Name|Case Number> <Rat 1> <Rat 2> <Rat 3>")
@@ -189,9 +186,7 @@ async def cmd_case_management_assign(ctx: Context):
     )
 
 
-@require_channel
-@require_permission(RAT)
-@command("clear", "close")
+@command("clear", "close", require_permission=RAT, require_channel=True)
 async def cmd_case_management_clear(ctx: Context):
     if not CLEAR_PATTERN.matches(ctx.words_eol[0]):
         await ctx.reply("Usage: !clear <Client Name|Board Index> [First Limpet Sender]")
@@ -230,9 +225,7 @@ async def cmd_case_management_clear(ctx: Context):
     await ctx.reply(f"Case {case.client} was cleared!")
 
 
-@require_channel
-@require_permission(RAT)
-@command("cmdr", "commander")
+@command("cmdr", "commander", require_channel=True, require_permission=RAT)
 async def cmd_case_management_cmdr(ctx: Context):
     if not CMDR_PATTERN.matches(ctx.words_eol[0]):
         await ctx.reply("Usage: !cmdr <Client Name|Board Index> <CMDR name>")
@@ -250,9 +243,8 @@ async def cmd_case_management_cmdr(ctx: Context):
         await ctx.reply(f"Client for {case.board_index} is now CMDR {case.client}")
 
 
-@require_channel
-@require_channel(RAT)
-@command("codered", "casered", "cr")
+
+@command("codered", "casered", "cr", require_channel=True, require_permission=RAT)
 async def cmd_case_management_codered(ctx: Context):
     if not CODE_RED_PATTERN.matches(ctx.words_eol[0]):
         await ctx.reply("Usage: !codered <Client Name|Board Index>")
@@ -282,9 +274,7 @@ async def cmd_case_management_codered(ctx: Context):
             await ctx.reply(f"{case.client} is no longer a Code Red.")
 
 
-@require_channel
-@require_permission(OVERSEER)
-@command("delete")
+@command("delete", require_channel=True, require_permission=OVERSEER)
 async def cmd_case_management_delete(ctx: Context):
     if len(ctx.words) < 2:
         await ctx.reply("Usage: !delete <API ID>")
@@ -306,9 +296,7 @@ async def cmd_case_management_delete(ctx: Context):
         await ctx.bot.board.remove_rescue(rescue)
 
 
-@require_channel
-@require_permission(RAT)
-@command("epic")
+@command("epic", require_channel=True, require_permission=RAT)
 async def cmd_case_management_epic(ctx: Context):
     # This command may be depreciated, and not used.  It's left in only as an artifact, or
     # if that changes.
@@ -316,36 +304,10 @@ async def cmd_case_management_epic(ctx: Context):
         "This command is no longer in use.  "
         "Please visit https://fuelrats.com/epic/nominate to nominate an epic rescue."
     )
-    return
-    # End Depreciation warning
-
-    if len(ctx.words) < 3:
-        await ctx.reply("Usage: !epic <Client Name|Board Index> <Description>")
-        return
-
-    # Pass case to validator, return a case if found or None
-    rescue = _validate(ctx, ctx.words[1])
-
-    if not rescue:
-        await ctx.reply("No case with that name or number.")
-        return
-
-    if rescue.epic:
-        await ctx.reply(f"{rescue.client}'s case is already considered an epic tale.")
-        return
-
-    new_epic = Epic(uuid=rescue.api_id, notes=ctx.words_eol[2], rescue=rescue)
-    async with ctx.bot.board.modify_rescue(rescue) as case:
-        case.epic.append(new_epic)
-        await ctx.reply(
-            f"{case.client}'s rescue has been marked as an " f"EPIC tale by {ctx.user.nickname}!"
-        )
-        await ctx.reply(f"Description: {new_epic.notes}")
+    warnings.warn("call to deprecated command", DeprecationWarning)
 
 
-@require_channel
-@require_permission(RAT)
-@command("grab")
+@command("grab", require_channel=True, require_permission=RAT)
 async def cmd_case_management_grab(ctx: Context):
     if not GRAB_PATTERN.matches(ctx.words_eol[0]):
         await ctx.reply("Usage: !grab <Client Name>")
@@ -388,9 +350,7 @@ async def cmd_case_management_grab(ctx: Context):
         )
 
 
-@require_channel
-@require_permission(RAT)
-@command("inject")
+@command("inject", require_channel=True, require_permission=RAT)
 async def cmd_case_management_inject(ctx: Context):
     if not INJECT_PATTERN.matches(ctx.words_eol[0]):
         logger.debug("pattern match failed.")
@@ -445,9 +405,7 @@ async def cmd_case_management_inject(ctx: Context):
     )
 
 
-@require_channel
-@require_permission(RAT)
-@command("ircnick", "nick", "nickname")
+@command("ircnick", "nick", "nickname", require_channel=True, require_permission=RAT)
 async def cmd_case_management_ircnick(ctx: Context):
     if not IRC_NICK_PATTERN.matches(ctx.words_eol[0]):
         return await ctx.reply("Usage: !ircnick <Client Name|Board Index> <New Client Name>")
@@ -475,9 +433,7 @@ async def cmd_case_management_ircnick(ctx: Context):
         )
 
 
-@require_channel
-@require_permission(RAT)
-@command("pc", "ps", "xb")
+@command("pc", "ps", "xb", require_channel=True, require_permission=RAT)
 async def cmd_case_management_system(ctx: Context):
     if not JUST_RESCUE_PATTERN.matches(ctx.words_eol[0]):
         return await ctx.reply("Usage: !<pc|ps|xb> <Client Name|Board Index>")
@@ -493,9 +449,7 @@ async def cmd_case_management_system(ctx: Context):
         await ctx.reply(f"{case.client}'s platform set to {case.platform.value}.")
 
 
-@require_channel()
-@require_permission(RAT)
-@command("quote")
+@command("quote", require_channel=True, require_permission=RAT)
 async def cmd_case_management_quote(ctx: Context):
     if not JUST_RESCUE_PATTERN.matches(ctx.words_eol[0]):
         await ctx.reply("Usage: !quote <Client Name|Board Index>")
@@ -525,9 +479,7 @@ async def cmd_case_management_quote(ctx: Context):
             await ctx.reply(f"[{i}][{quote.author} ({quote_timestamp})] {quote.message}")
 
 
-@require_channel()
-@require_permission(OVERSEER)
-@command("quoteid")
+@command("quoteid", require_channel=True, require_permission=OVERSEER)
 async def cmd_case_management_quoteid(ctx: Context):
     # TODO: Remove NYI Message when API capability is ready.
     await ctx.reply("Use !quote.  API is not available in offline mode.")
@@ -570,9 +522,7 @@ async def cmd_case_management_quoteid(ctx: Context):
             await ctx.reply(f"[{i}][{quote.author} ({quote_timestamp})] {quote.message}")
 
 
-@require_channel()
-@require_permission(OVERSEER)
-@command("sub")
+@command("sub", require_channel=True, require_permission=OVERSEER)
 async def cmd_case_management_sub(ctx: Context):
     if not SUB_CMD_PATTERN.matches(ctx.words_eol[0]):
         return await ctx.reply("Usage: !sub <Client Name|Board Index> <Quote Number> [New Text]")
@@ -613,9 +563,7 @@ async def cmd_case_management_sub(ctx: Context):
         await ctx.reply(f"Deleted line {quote_id}.")
 
 
-@require_channel
-@require_permission(RAT)
-@command("sys", "loc", "location", "system")
+@command("sys", "loc", "location", "system", require_channel=True, require_permission=RAT)
 async def cmd_case_management_sys(ctx: Context):
     if not SYS_PATTERN.matches(ctx.words_eol[0]):
         return await ctx.reply("Usage: !sys <Client Name|Board Index> <New System>")
@@ -632,9 +580,7 @@ async def cmd_case_management_sys(ctx: Context):
         await ctx.reply(f"{case.client}'s system set to {tokens.remainder!r}")
 
 
-@require_channel
-@require_permission(RAT)
-@command("title")
+@command("title", require_channel=True, require_permission=RAT)
 async def cmd_case_management_title(ctx: Context):
     if not TITLE_PATTERN.matches(ctx.words_eol[0]):
         await ctx.reply("Usage: !title <Client Name|Board Index> <Operation Title")
@@ -652,9 +598,7 @@ async def cmd_case_management_title(ctx: Context):
         await ctx.reply(f"{case.client}'s rescue title set to {tokens.remainder!r}")
 
 
-@require_channel
-@require_permission(RAT)
-@command("unassign", "rm", "remove", "standdown")
+@command("unassign", "rm", "remove", "standdown", require_channel=True, require_permission=RAT)
 async def cmd_case_management_unassign(ctx: Context):
     if not UNASSIGN_PATTERN.matches(ctx.words_eol[0]):
         return await ctx.reply("Usage: !unassign <Client Name|Case Number> <Rat 1> <Rat 2> <Rat 3>")
@@ -808,9 +752,7 @@ def _rescue_filter(
     return not all(filters)
 
 
-@command("reopen")
-@require_channel
-@require_permission(OVERSEER)
+@command("reopen", require_channel=True, require_permission=OVERSEER)
 async def cmd_reopen(context: Context):
     """ Re-open a closed rescue """
     if not REOPEN_PATTERN.matches(context.words_eol[0]):

--- a/src/commands/case_management.py
+++ b/src/commands/case_management.py
@@ -25,7 +25,6 @@ from loguru import logger
 from ._list_flags import ListFlags
 from ..packages.commands import command
 from ..packages.context.context import Context
-from ..packages.epic import Epic
 from ..packages.parsing_rules import (
     rescue_identifier,
     irc_name,
@@ -36,10 +35,8 @@ from ..packages.parsing_rules import (
     api_id,
 )
 from ..packages.permissions.permissions import (
-    require_permission,
     RAT,
     OVERSEER,
-    require_channel,
 )
 from ..packages.quotation.rat_quotation import Quotation
 from ..packages.rat import Rat

--- a/src/commands/case_management.py
+++ b/src/commands/case_management.py
@@ -243,7 +243,6 @@ async def cmd_case_management_cmdr(ctx: Context):
         await ctx.reply(f"Client for {case.board_index} is now CMDR {case.client}")
 
 
-
 @command("codered", "casered", "cr", require_channel=True, require_permission=RAT)
 async def cmd_case_management_codered(ctx: Context):
     if not CODE_RED_PATTERN.matches(ctx.words_eol[0]):

--- a/src/commands/debug.py
+++ b/src/commands/debug.py
@@ -22,9 +22,7 @@ from src.packages.fuelrats_api.v3 import UnauthorizedImpersonation
 from src.packages.permissions.permissions import require_permission, TECHRAT, require_channel
 
 
-@command("debug-whois")
-@require_channel
-@require_permission(TECHRAT)
+@command("debug-whois", require_channel=True, require_permission=TECHRAT)
 async def cmd_debug_whois(context):
     """A debug command for running a WHOIS command.
 
@@ -36,9 +34,7 @@ async def cmd_debug_whois(context):
     await context.reply(f"{data}")
 
 
-@command("debug-userinfo")
-@require_permission(TECHRAT)
-@require_channel
+@command("debug-userinfo", require_channel=True, require_permission=TECHRAT)
 async def cmd_debug_userinfo(context: Context):
     """
     A debug command for getting information about a user.
@@ -50,20 +46,7 @@ async def cmd_debug_userinfo(context: Context):
     )
 
 
-@command("superPing!")
-@require_channel
-@require_permission(TECHRAT)
-async def cmd_superping(context: Context):
-    """
-    A debug command to coerce mecha to respond.
-    """
-
-    await context.reply("pong!")
-
-
-@command("getConfigPlugins")
-@require_channel
-@require_permission(TECHRAT)
+@command("getConfigPlugins", require_channel=True, require_permission=TECHRAT)
 async def cmd_get_plugins(context: Context):
     """Lists configuration plugins"""
     await context.reply(f"getting plugins...")
@@ -73,9 +56,7 @@ async def cmd_get_plugins(context: Context):
     await context.reply(",".join(names))
 
 
-@command("get_nickname_api")
-@require_channel
-@require_permission(TECHRAT)
+@command("get_nickname_api", require_channel=True, require_permission=TECHRAT)
 async def cmd_get_nickname(context: Context):
     await context.reply("fetching....")
     result = await context.bot.api_handler.get_rat(
@@ -85,9 +66,7 @@ async def cmd_get_nickname(context: Context):
     logger.debug("got nickname result {!r}", result)
 
 
-@command("debug_ratid")
-@require_channel
-@require_permission(TECHRAT)
+@command("debug_ratid", require_channel=True, require_permission=TECHRAT)
 async def cmd_ratid(context: Context):
     target = context.words[-1]
     await context.reply(f"acquiring ratids for {target!r}...")
@@ -97,9 +76,7 @@ async def cmd_ratid(context: Context):
     await context.reply(",".join([f"{rat.uuid}" for rat in api_rats]))
 
 
-@command("debug_get_rat")
-@require_channel
-@require_permission(TECHRAT)
+@command("debug_get_rat", require_channel=True, require_permission=TECHRAT)
 async def cmd_debug_get_rat(context: Context):
     target = context.words[-1]
     try:
@@ -111,9 +88,7 @@ async def cmd_debug_get_rat(context: Context):
     await context.reply(f"identified rats: {','.join(repr(obj.name) for obj in subject)}")
 
 
-@command("debug_summoncase")
-@require_channel
-@require_permission(TECHRAT)
+@command("debug_summoncase", require_channel=True, require_permission=TECHRAT)
 async def cmd_debug_summoncase(context: Context):
     await context.reply("summoning case....")
     rescue = await context.bot.board.create_rescue(client="some_client")
@@ -121,9 +96,7 @@ async def cmd_debug_summoncase(context: Context):
     await context.reply("done.")
 
 
-@command("debug_fbr")
-@require_channel
-@require_permission(TECHRAT)
+@command("debug_fbr", require_channel=True, require_permission=TECHRAT)
 async def cmd_debug_fetch(context: Context):
     await context.reply("flushing my board and fetching...")
     keys = context.bot.board.keys()
@@ -142,9 +115,7 @@ async def cmd_debug_fetch(context: Context):
         await context.bot.board.append(rescue)
 
 
-@command("debug_fetch_rescue")
-@require_channel
-@require_permission(TECHRAT)
+@command("debug_fetch_rescue", require_channel=True, require_permission=TECHRAT)
 async def cmd_debug_fetch_single(context: Context):
     uid = UUID(context.words[-1])
     await context.reply(f"fetching @{uid}...")
@@ -155,9 +126,7 @@ async def cmd_debug_fetch_single(context: Context):
         await context.reply("go fish.")
 
 
-@command("debug_update_rescue")
-@require_channel
-@require_permission(TECHRAT)
+@command("debug_update_rescue", require_channel=True, require_permission=TECHRAT)
 async def cmd_update_rescue(context: Context):
     uid = UUID(context.words[-1])
     if uid not in context.bot.board:
@@ -175,9 +144,7 @@ async def cmd_update_rescue(context: Context):
     await context.reply("done.")
 
 
-@command("debug_go_online")
-@require_channel
-@require_permission(TECHRAT)
+@command("debug_go_online", require_channel=True, require_permission=TECHRAT)
 async def cmd_debug_go_online(context: Context):
     await context.reply("going online...")
     context.bot.board.api_handler = context.bot.api_handler

--- a/src/commands/debug.py
+++ b/src/commands/debug.py
@@ -19,7 +19,7 @@ from src.config import PLUGIN_MANAGER
 from src.packages.commands import command
 from src.packages.context.context import Context
 from src.packages.fuelrats_api.v3 import UnauthorizedImpersonation
-from src.packages.permissions.permissions import require_permission, TECHRAT, require_channel
+from src.packages.permissions.permissions import TECHRAT
 
 
 @command("debug-whois", require_channel=True, require_permission=TECHRAT)

--- a/src/commands/deletion_management.py
+++ b/src/commands/deletion_management.py
@@ -44,9 +44,7 @@ def _validate(ctx: Context, validate: str) -> Optional[Rescue]:
     return rescue
 
 
-@require_channel
-@require_permission(RAT)
-@command("md", "mdadd")
+@command("md", "mdadd", require_channel=True, require_permission=RAT)
 async def del_management_md(ctx: Context):
     if len(ctx.words) <= 2:
         await ctx.reply("Usage: !md <Client Name|Board Index> <Reason for Deletion>")
@@ -73,9 +71,7 @@ async def del_management_md(ctx: Context):
     await ctx.bot.board.remove_rescue(rescue)
 
 
-@require_channel
-@require_permission(OVERSEER)
-@command("mdlist")
+@command("mdlist", require_permission=OVERSEER, require_direct_message=True)
 async def del_management_mdlist(ctx: Context):
     await ctx.reply("Marked for Deletion List:")
 

--- a/src/commands/deletion_management.py
+++ b/src/commands/deletion_management.py
@@ -17,10 +17,8 @@ from ..packages.commands import command
 from ..packages.context.context import Context
 from ..packages.mark_for_deletion import MarkForDeletion
 from ..packages.permissions.permissions import (
-    require_permission,
     RAT,
     OVERSEER,
-    require_channel,
 )
 from ..packages.rescue import Rescue
 from ..packages.utils import Status

--- a/src/commands/starsystems.py
+++ b/src/commands/starsystems.py
@@ -5,8 +5,7 @@ import pyparsing
 from loguru import logger
 
 
-@permissions.require_permission(permissions.RAT)
-@command("search")
+@command("search", require_permission=permissions.RAT)
 async def cmd_search(ctx: Context):
     if len(ctx.words) != 2:
         return await ctx.reply("Usage: search <name of system>")
@@ -25,8 +24,7 @@ async def cmd_landmark_near(ctx: Context, system_name: str):
     return await ctx.reply(f"{found.name} is {distance:.2f} LY from {nearest_landmark.name}")
 
 
-@permissions.require_permission(permissions.RAT)
-@command("landmark")
+@command("landmark", require_permission=permissions.RAT)
 @logger.catch(level="DEBUG")
 async def cmd_landmark(ctx: Context):
     keyword = pyparsing.oneOf("near", asKeyword=True).setResultsName("subcommand")

--- a/src/config/_parser.py
+++ b/src/config/_parser.py
@@ -62,7 +62,7 @@ def setup_logging(logfile: str, gelf_configuration: Optional[GelfConfig] = None)
     handlers = [
         dict(
             sink=sys.stdout,
-            format="<b><c><{time}</c></b> [{name}] " "<level>{level.name}</level> > {message}",
+            format="<b><c><{time}</c></b> [{name}] | {extra} | " "<level>{level.name}</level> > {message}",
             colorize=True,
             backtrace=False,
             diagnose=False,

--- a/src/config/_parser.py
+++ b/src/config/_parser.py
@@ -62,7 +62,8 @@ def setup_logging(logfile: str, gelf_configuration: Optional[GelfConfig] = None)
     handlers = [
         dict(
             sink=sys.stdout,
-            format="<b><c><{time}</c></b> [{name}] | {extra} | " "<level>{level.name}</level> > {message}",
+            format="<b><c><{time}</c></b> [{name}] | {extra} | "
+            "<level>{level.name}</level> > {message}",
             colorize=True,
             backtrace=False,
             diagnose=False,

--- a/src/packages/commands/rat_command.py
+++ b/src/packages/commands/rat_command.py
@@ -150,7 +150,7 @@ class Command:
                         logger.warning("A user tried to invoke a DM only message in a channel.")
                         return await context.reply(
                             "Cannot comply: this command must be invoked in a direct message."
-                            if self.override_dm_message is not None
+                            if self.override_dm_message is None
                             else self.override_dm_message
                         )
             with TIME_IN_COMMAND.labels(command=self.aliases[0]).time():

--- a/src/packages/commands/rat_command.py
+++ b/src/packages/commands/rat_command.py
@@ -87,7 +87,7 @@ _registered_commands = {}  # pylint: disable=invalid-name
 
 def truthy_validator(inst, attribute, value):
     if not value:
-        raise ValueError(value)
+        raise ValueError(f"attribute {attribute.name!r} must be truthy.")
 
 
 @attr.dataclass

--- a/src/packages/commands/rat_command.py
+++ b/src/packages/commands/rat_command.py
@@ -127,7 +127,19 @@ class Command:
                             if self.require_permission_message is not None
                             else self.require_permission.denied_message
                         )
+                if self.require_channel:
+                    if context.channel is None:
+                        logger.warning("A user tried to invoke a channel message in a direct message.")
+                        return await context.reply(
+                            "Cannot comply: This command must be invoked in a channel."
+                        )
 
+                if self.require_direct_message:
+                    if context.channel is not None:
+                        logger.warning("A user tried to invoke a DM only message in a channel.")
+                        return await context.reply(
+                            "Cannot comply: this command must be invoked in a direct message."
+                        )
             with TIME_IN_COMMAND.labels(command=self.aliases[0]).time():
                 return await self.underlying(context, *args, **kwargs)
 

--- a/src/packages/permissions/__init__.py
+++ b/src/packages/permissions/__init__.py
@@ -18,10 +18,11 @@ __all__ = [
     "RECRUIT",
     "OVERSEER",
     "ADMIN",
+    "has_required_permission"
 ]
 from src.config import PLUGIN_MANAGER
 from .permissions import Permission, require_permission, require_dm, require_channel, RAT, \
-    TECHRAT, RECRUIT, OVERSEER, ADMIN
+    TECHRAT, RECRUIT, OVERSEER, ADMIN, has_required_permission
 from . import permissions
 
 PLUGIN_MANAGER.register(permissions)

--- a/src/packages/permissions/permissions.py
+++ b/src/packages/permissions/permissions.py
@@ -22,6 +22,7 @@ import prometheus_client
 from prometheus_async.aio import time as aio_time
 
 from ...config.datamodel import ConfigRoot
+import warnings
 
 REQUIRE_PERMISSION_TIME = prometheus_client.Summary("permissions_require_permissions_seconds",
                                                     "time in require_permission")
@@ -285,6 +286,7 @@ def require_permission(permission: Permission,
     Returns:
 
     """
+    warnings.warn("deprecated API, pass require_permission=Permission to @command", DeprecationWarning)
 
     def real_decorator(func):
         logger.debug("Inside the real_decorator")

--- a/src/packages/permissions/permissions.py
+++ b/src/packages/permissions/permissions.py
@@ -14,7 +14,7 @@ This module is built on top of the Pydle system.
 import cattr
 from loguru import logger
 from functools import wraps
-from typing import Any, Union, Callable, Dict, Set
+from typing import Any, Union, Callable, Dict, Set, TYPE_CHECKING
 
 from src.config import CONFIG_MARKER
 from ..context import Context

--- a/src/packages/permissions/permissions.py
+++ b/src/packages/permissions/permissions.py
@@ -327,6 +327,8 @@ def require_channel(func: Union[str, Callable] = None,
         ... async def my_command(context: Context):
         ...     pass
     """
+    warnings.warn("deprecated API, pass require_channel=bool to @command", DeprecationWarning)
+
     # form of @decorator("message") and @decorator(message=str)
     if isinstance(func, str):
         message = func
@@ -397,6 +399,8 @@ def require_dm(func: Union[str, Callable] = None,
         ... async def my_command(context: Context):
         ...     pass
     """
+    warnings.warn("deprecated API, pass require_dm=bool to @command", DeprecationWarning)
+
     # form of @decorator("message") and @decorator(message=str)
     if isinstance(func, str):
         message = func

--- a/tests/unit/commands/test_administration.py
+++ b/tests/unit/commands/test_administration.py
@@ -12,43 +12,52 @@ See LICENSE.md
 import logging
 
 from src.commands import administration
+from src.packages.commands import trigger
 from src.packages.context import Context
 
-LOG = logging.getLogger(f"mecha.{__name__}")
 import pytest
 import string
 
+pytestmark = [pytest.mark.unit, pytest.mark.commands]
+
 @pytest.mark.asyncio
-async def test_rehash_dm(context_pm_fx, bot_fx, async_callable_fx, monkeypatch):
+async def test_rehash_dm(context_pm_fx, bot_fx, callable_fx, monkeypatch):
     """
     Verifies rehash tells off the user when they attempt to invoke the command in private.
     """
 
-    monkeypatch.setattr(administration, "setup", async_callable_fx)
-    async_callable_fx.return_value = ({}, '22aa')
-
-    await administration.cmd_rehash(context_pm_fx)
+    monkeypatch.setattr(administration, "setup", callable_fx)
+    callable_fx.return_value = ({}, '22aa')
+    ctx = await Context.from_message(
+        bot_fx, channel="non_channel",
+        sender="some_admin", message="!rehash"
+    )
+    await trigger(ctx=ctx)
 
     assert "everyone can see" in bot_fx.sent_messages[0]['message']
-    assert not async_callable_fx.was_called
+    assert not callable_fx.was_called
 
 
 @pytest.mark.asyncio
-async def test_rehash_not_authorized(bot_fx, async_callable_fx, monkeypatch):
+async def test_rehash_not_authorized(bot_fx, callable_fx, monkeypatch):
     context = await Context.from_message(bot_fx, "#unittest", "some_recruit", "!rehash 👿")
 
-    monkeypatch.setattr(administration, "setup", async_callable_fx)
-    async_callable_fx.return_value = ({}, '22aa')
+    monkeypatch.setattr(administration, "setup", callable_fx)
+    callable_fx.return_value = ({}, '22aa')
 
-    await administration.cmd_rehash(context=context)
+    ctx = await Context.from_message(
+        bot_fx, channel="non_channel",
+        sender="some_recruit", message="!rehash"
+    )
+    await trigger(ctx)
 
     assert "no." == bot_fx.sent_messages[0]['message']
-    assert not async_callable_fx.was_called
+    assert not callable_fx.was_called
 
 
 @pytest.mark.parametrize("exc_class", (ValueError, KeyError))
 @pytest.mark.asyncio
-async def test_rehash_application_failure(bot_fx, async_callable_fx, monkeypatch, exc_class, ):
+async def test_rehash_application_failure(bot_fx, callable_fx, monkeypatch, exc_class, ):
     """
     verifies the commands behavior when the setup() call fails (predictably).
     """

--- a/tests/unit/test_permissions.py
+++ b/tests/unit/test_permissions.py
@@ -22,13 +22,11 @@ from src.packages.context import Context
 from src.packages.permissions import permissions
 from src.packages.permissions import require_permission, require_channel, require_dm, Permission
 
-
+pytestmark = [pytest.mark.unit, pytest.mark.permissions]
 
 @pytest.fixture
-def restricted_command_fx(async_callable_fx):
-    restricted = require_permission(permissions.OVERSEER)(async_callable_fx)
-
-    Commands.command("restricted")(restricted)
+def restricted_command_fx(async_callable_fx, configuration_fx):
+    Commands.command("restricted", require_permission=permissions.OVERSEER)(async_callable_fx)
     yield  async_callable_fx
     del Commands._registered_commands["restricted"]
 
@@ -101,6 +99,7 @@ class TestPermissions(object):
     async def test_restricted_command_exact(self, bot_fx, restricted_command_fx):
         context = await Context.from_message(bot_fx, "#somechannel", "some_ov", "!restricted")
         await Commands.trigger(context)
+        assert restricted_command_fx.was_called
         assert restricted_command_fx.was_called_once
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Command guards have been implemented inconsistently thoughout the codebase, and its past due that things get cleaned up in this regard.

The groundwork for this has already been implemented in #185 but stopped short of completing SPARK-185 due to scoping issues. This PR completes SPARK-185.

# Deprications
These decorators are now depricated and should not be used. perhaps we should purge them from the codebase while we are here...

Their functionality has been implemented directly in `@command`, using keyword arguments. See below example.

```py

@command(
    "rehash",
    require_channel=True,
    override_channel_message="please do this where everyone can see 😒",
    require_permission=TECHRAT,
    require_permission_message="no.",
)
async def cmd_rehash(context: Context): 
```
 
- `@require_channel`
- `@require_permission`
- `@require_direct_message`
