### PR TITLE
SPARK-188 Allow !md in privmsg and tests added

### DIFF
--- a/src/commands/deletion_management.py
+++ b/src/commands/deletion_management.py
@@ -42,7 +42,7 @@ def _validate(ctx: Context, validate: str) -> Optional[Rescue]:
     return rescue
 
 
-@command("md", "mdadd", require_channel=True, require_permission=RAT)
+@command("md", "mdadd", require_permission=RAT)
 async def del_management_md(ctx: Context):
     if len(ctx.words) <= 2:
         await ctx.reply("Usage: !md <Client Name|Board Index> <Reason for Deletion>")

--- a/src/packages/database/database_manager.py
+++ b/src/packages/database/database_manager.py
@@ -111,21 +111,26 @@ class DatabaseManager:
             # Utilize function arguments if they are provided,
             # otherwise retrieve from config file and use those values.
             self._dbhost = dbhost if dbhost is not None else self._config.database.host
-            assert self._dbhost
+            if not self._dbhost:
+                raise AssertionError("_dbhost is not set")
 
             self._dbport = dbport if dbhost is not None else self._config.database.port
-            assert self._dbport
+            if not self._dbport:
+                raise AssertionError("_dbhost is not set")
 
             self._dbname = dbname if dbname is not None else self._config.database.dbname
-            assert self._dbname
+            if not self._dbname:
+                raise AssertionError("_dbhost is not set")
 
             self._dbuser = dbuser if dbuser is not None else self._config.database.username
-            assert self._dbuser
+            if not self._dbuser:
+                raise AssertionError("_dbhost is not set")
 
             self._dbpass = (
                 dbpassword if dbpassword is not None else self._config.database.password
             )
-            assert self._dbpass
+            if not self._dbpass:
+                raise AssertionError("_dbhost is not set")
 
         # Create Database Connections Pool
         try:

--- a/src/packages/rescue/rat_rescue.py
+++ b/src/packages/rescue/rat_rescue.py
@@ -402,7 +402,8 @@ class Rescue:  # pylint: disable=too-many-public-methods
             Fuelrats Api v2.1
         """
 
-        assert value is None or isinstance(value, str)
+        if not (value is None or isinstance(value, str)):
+            raise TypeError("value must be of type None or str")
 
         if value is None:
             # System must be nullable, so we specifically check for it

--- a/tests/unit/test_rat_command.py
+++ b/tests/unit/test_rat_command.py
@@ -252,3 +252,35 @@ class TestRatCommand(object):
         assert f"{random_string_fx}'s case is now Inactive." in bot_fx.sent_messages[1]['message']
         assert f"{random_string_fx}'s case updated with: 'test inject message' (Case {rescue.board_index})" in bot_fx.sent_messages[2]['message']
         assert f"{random_string_fx}'s case is now Active." in bot_fx.sent_messages[3]['message']
+
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("alias", ["md", "mdadd"])
+    @pytest.mark.parametrize("channel", ["#unittest", "some_rat"])
+    async def test_call_command_md(
+        self, alias, channel, bot_fx, configuration_fx, rat_board_fx, rescue_sop_fx
+    ):
+        assert (
+            rescue_sop_fx.marked_for_deletion.marked == False
+        ), "UNEXPECTED: SOP rescue already marked for deletion"
+        bot_fx.board = rat_board_fx
+        await bot_fx.board.append(rescue_sop_fx)
+        assert len(bot_fx.board) == 1, f"Setting up a test case failed"
+
+        trigger_alias = f"{configuration_fx.commands.prefix}{alias} {rescue_sop_fx.board_index}"
+        logger.debug(f"Triggering alias: {trigger_alias}")
+        await Commands.trigger(await Context.from_message(bot_fx, channel, "some_rat", trigger_alias))
+        assert len(bot_fx.board) == 1, f"Case got closed by {trigger_alias} [without inject message]"
+        assert (
+            not rescue_sop_fx.marked_for_deletion.marked
+        ), "SOP rescue became marked for deletion [without inject message]"
+
+        trigger_alias = (
+            f"{configuration_fx.commands.prefix}{alias} {rescue_sop_fx.board_index} Closing test case"
+        )
+        logger.debug(f"Triggering alias: {trigger_alias}")
+        await Commands.trigger(await Context.from_message(bot_fx, channel, "some_rat", trigger_alias))
+        assert len(bot_fx.board) == 0, f"Case did not get closed by {trigger_alias}"
+        assert (
+            rescue_sop_fx.marked_for_deletion.marked
+        ), "SOP rescue did not become marked for deletion"


### PR DESCRIPTION
With the rescue revisions, marking deletion does not need to be send in a channel anymore. Deletion also creates a rescue revision.